### PR TITLE
实现 #30

### DIFF
--- a/src/main/java/moe/yushi/authlibinjector/AuthlibInjector.java
+++ b/src/main/java/moe/yushi/authlibinjector/AuthlibInjector.java
@@ -313,15 +313,12 @@ public final class AuthlibInjector {
 		}
 
 		filters.add(new QueryUUIDsFilter(mojangClient, customClient));
-		QueryProfileFilter queryProfileFilter = new QueryProfileFilter(mojangClient, customClient);
-		filters.add(queryProfileFilter);
+		filters.add(new QueryProfileFilter(mojangClient, customClient));
 
-		MC52974Workaround mc52974 = new MC52974Workaround();
 		MainArgumentsTransformer.getListeners().add(args -> {
-			mc52974.acceptMainArguments(args);
+			MC52974Workaround.acceptMainArguments(args);
 			return args;
 		});
-		queryProfileFilter.setMc52974Workaround(mc52974);
 
 		return filters;
 	}
@@ -345,6 +342,7 @@ public final class AuthlibInjector {
 		transformer.units.add(new MainArgumentsTransformer());
 		transformer.units.add(new ConstantURLTransformUnit(urlProcessor));
 		transformer.units.add(new CitizensTransformer());
+		transformer.units.add(new MC52974Workaround());
 		transformer.units.add(new LaunchWrapperTransformer());
 
 		transformer.units.add(new SkinWhitelistTransformUnit(config.getSkinDomains().toArray(new String[0])));

--- a/src/main/java/moe/yushi/authlibinjector/httpd/QueryProfileFilter.java
+++ b/src/main/java/moe/yushi/authlibinjector/httpd/QueryProfileFilter.java
@@ -40,6 +40,9 @@ public class QueryProfileFilter implements URLFilter {
 	private YggdrasilClient mojangClient;
 	private YggdrasilClient customClient;
 
+	// see <https://github.com/yushijinhun/authlib-injector/issues/30>
+	private boolean mc52974WorkaroundEnabled;
+
 	public QueryProfileFilter(YggdrasilClient mojangClient, YggdrasilClient customClient) {
 		this.mojangClient = mojangClient;
 		this.customClient = customClient;
@@ -71,6 +74,10 @@ public class QueryProfileFilter implements URLFilter {
 			withSignature = true;
 		}
 
+		if (mc52974WorkaroundEnabled) {
+			withSignature = true;
+		}
+
 		Optional<GameProfile> response;
 		if (QueryUUIDsFilter.isMaskedUUID(uuid)) {
 			response = mojangClient.queryProfile(QueryUUIDsFilter.unmaskUUID(uuid), withSignature);
@@ -89,4 +96,11 @@ public class QueryProfileFilter implements URLFilter {
 		}
 	}
 
+	public boolean isMc52974WorkaroundEnabled() {
+		return mc52974WorkaroundEnabled;
+	}
+
+	public void setMc52974WorkaroundEnabled(boolean mc52974WorkaroundEnabled) {
+		this.mc52974WorkaroundEnabled = mc52974WorkaroundEnabled;
+	}
 }

--- a/src/main/java/moe/yushi/authlibinjector/httpd/QueryProfileFilter.java
+++ b/src/main/java/moe/yushi/authlibinjector/httpd/QueryProfileFilter.java
@@ -29,6 +29,7 @@ import java.util.regex.Pattern;
 import moe.yushi.authlibinjector.internal.fi.iki.elonen.IHTTPSession;
 import moe.yushi.authlibinjector.internal.fi.iki.elonen.Response;
 import moe.yushi.authlibinjector.internal.fi.iki.elonen.Status;
+import moe.yushi.authlibinjector.transform.support.MC52974Workaround;
 import moe.yushi.authlibinjector.yggdrasil.GameProfile;
 import moe.yushi.authlibinjector.yggdrasil.YggdrasilClient;
 import moe.yushi.authlibinjector.yggdrasil.YggdrasilResponseBuilder;
@@ -40,8 +41,7 @@ public class QueryProfileFilter implements URLFilter {
 	private YggdrasilClient mojangClient;
 	private YggdrasilClient customClient;
 
-	// see <https://github.com/yushijinhun/authlib-injector/issues/30>
-	private boolean mc52974WorkaroundEnabled;
+	private MC52974Workaround mc52974Workaround;
 
 	public QueryProfileFilter(YggdrasilClient mojangClient, YggdrasilClient customClient) {
 		this.mojangClient = mojangClient;
@@ -74,7 +74,7 @@ public class QueryProfileFilter implements URLFilter {
 			withSignature = true;
 		}
 
-		if (mc52974WorkaroundEnabled) {
+		if (mc52974Workaround != null && mc52974Workaround.needsWorkaround()) {
 			withSignature = true;
 		}
 
@@ -96,11 +96,7 @@ public class QueryProfileFilter implements URLFilter {
 		}
 	}
 
-	public boolean isMc52974WorkaroundEnabled() {
-		return mc52974WorkaroundEnabled;
-	}
-
-	public void setMc52974WorkaroundEnabled(boolean mc52974WorkaroundEnabled) {
-		this.mc52974WorkaroundEnabled = mc52974WorkaroundEnabled;
+	public void setMc52974Workaround(MC52974Workaround mc52974Workaround) {
+		this.mc52974Workaround = mc52974Workaround;
 	}
 }

--- a/src/main/java/moe/yushi/authlibinjector/httpd/QueryProfileFilter.java
+++ b/src/main/java/moe/yushi/authlibinjector/httpd/QueryProfileFilter.java
@@ -29,7 +29,6 @@ import java.util.regex.Pattern;
 import moe.yushi.authlibinjector.internal.fi.iki.elonen.IHTTPSession;
 import moe.yushi.authlibinjector.internal.fi.iki.elonen.Response;
 import moe.yushi.authlibinjector.internal.fi.iki.elonen.Status;
-import moe.yushi.authlibinjector.transform.support.MC52974Workaround;
 import moe.yushi.authlibinjector.yggdrasil.GameProfile;
 import moe.yushi.authlibinjector.yggdrasil.YggdrasilClient;
 import moe.yushi.authlibinjector.yggdrasil.YggdrasilResponseBuilder;
@@ -40,8 +39,6 @@ public class QueryProfileFilter implements URLFilter {
 
 	private YggdrasilClient mojangClient;
 	private YggdrasilClient customClient;
-
-	private MC52974Workaround mc52974Workaround;
 
 	public QueryProfileFilter(YggdrasilClient mojangClient, YggdrasilClient customClient) {
 		this.mojangClient = mojangClient;
@@ -74,10 +71,6 @@ public class QueryProfileFilter implements URLFilter {
 			withSignature = true;
 		}
 
-		if (mc52974Workaround != null && mc52974Workaround.needsWorkaround()) {
-			withSignature = true;
-		}
-
 		Optional<GameProfile> response;
 		if (QueryUUIDsFilter.isMaskedUUID(uuid)) {
 			response = mojangClient.queryProfile(QueryUUIDsFilter.unmaskUUID(uuid), withSignature);
@@ -96,7 +89,4 @@ public class QueryProfileFilter implements URLFilter {
 		}
 	}
 
-	public void setMc52974Workaround(MC52974Workaround mc52974Workaround) {
-		this.mc52974Workaround = mc52974Workaround;
-	}
 }

--- a/src/main/java/moe/yushi/authlibinjector/transform/MainArgumentsTransformer.java
+++ b/src/main/java/moe/yushi/authlibinjector/transform/MainArgumentsTransformer.java
@@ -1,0 +1,71 @@
+package moe.yushi.authlibinjector.transform;
+
+import static java.util.stream.Collectors.joining;
+import static org.objectweb.asm.Opcodes.ALOAD;
+import static org.objectweb.asm.Opcodes.ASM7;
+import static org.objectweb.asm.Opcodes.ASTORE;
+import static org.objectweb.asm.Opcodes.INVOKESTATIC;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.function.Function;
+import java.util.stream.Stream;
+
+import org.objectweb.asm.ClassVisitor;
+import org.objectweb.asm.MethodVisitor;
+import org.objectweb.asm.Type;
+
+import moe.yushi.authlibinjector.util.Logging;
+
+public class MainArgumentsTransformer implements TransformUnit {
+
+	private static final List<Function<String[], String[]>> LISTENERS = new CopyOnWriteArrayList<>();
+
+	public static String[] processMainArguments(String[] args) {
+		Logging.TRANSFORM.fine(() -> "Main arguments: " + Stream.of(args).collect(joining(" ")));
+
+		String[] result = args;
+		for (Function<String[], String[]> listener : LISTENERS) {
+			result = listener.apply(result);
+		}
+		return result;
+	}
+
+	public static List<Function<String[], String[]>> getListeners() {
+		return LISTENERS;
+	}
+
+	@Override
+	public Optional<ClassVisitor> transform(ClassLoader classLoader, String className, ClassVisitor writer, Runnable modifiedCallback) {
+		if ("net.minecraft.client.main.Main".equals(className)) {
+			return Optional.of(new ClassVisitor(ASM7, writer) {
+				@Override
+				public MethodVisitor visitMethod(int access, String name, String descriptor, String signature, String[] exceptions) {
+					if ("main".equals(name) && "([Ljava/lang/String;)V".equals(descriptor)) {
+						return new MethodVisitor(ASM7, super.visitMethod(access, name, descriptor, signature, exceptions)) {
+							@Override
+							public void visitCode() {
+								super.visitCode();
+								modifiedCallback.run();
+
+								super.visitVarInsn(ALOAD, 0);
+								super.visitMethodInsn(INVOKESTATIC, Type.getInternalName(MainArgumentsTransformer.class), "processMainArguments", "([Ljava/lang/String;)[Ljava/lang/String;", false);
+								super.visitVarInsn(ASTORE, 0);
+							}
+						};
+					} else {
+						return super.visitMethod(access, name, descriptor, signature, exceptions);
+					}
+				}
+			});
+		} else {
+			return Optional.empty();
+		}
+	}
+
+	@Override
+	public String toString() {
+		return "Main Arguments Transformer";
+	}
+}

--- a/src/main/java/moe/yushi/authlibinjector/transform/support/MC52974Workaround.java
+++ b/src/main/java/moe/yushi/authlibinjector/transform/support/MC52974Workaround.java
@@ -1,20 +1,32 @@
 package moe.yushi.authlibinjector.transform.support;
 
 import static java.util.Collections.unmodifiableSet;
+import static org.objectweb.asm.Opcodes.ASM7;
+import static org.objectweb.asm.Opcodes.ILOAD;
+import static org.objectweb.asm.Opcodes.INVOKESTATIC;
+import static org.objectweb.asm.Opcodes.ISTORE;
 
 import java.util.Arrays;
 import java.util.HashSet;
 import java.util.Optional;
 import java.util.Set;
 
+import org.objectweb.asm.ClassVisitor;
+import org.objectweb.asm.MethodVisitor;
+import org.objectweb.asm.Type;
+
+import moe.yushi.authlibinjector.transform.TransformUnit;
 import moe.yushi.authlibinjector.util.Logging;
 
 /**
  * See <https://github.com/yushijinhun/authlib-injector/issues/30>
  */
-public class MC52974Workaround {
+public class MC52974Workaround implements TransformUnit {
 
-	private static final Set<String> AFFECTED_VERSION_SERIES = unmodifiableSet(new HashSet<>(Arrays.asList(
+	private static boolean affected = false;
+
+	// ==== Detect affected versions ====
+	public static final Set<String> AFFECTED_VERSION_SERIES = unmodifiableSet(new HashSet<>(Arrays.asList(
 			"1.7.4", // MC 1.7.9 uses this
 			"1.7.10",
 			"1.8",
@@ -23,22 +35,7 @@ public class MC52974Workaround {
 			"1.11",
 			"1.12")));
 
-	private boolean enabled;
-
-	public boolean needsWorkaround() {
-		return enabled;
-	}
-
-	public void acceptMainArguments(String[] args) {
-		parseArgument(args, "--assetIndex").ifPresent(assetIndexName -> {
-			if (AFFECTED_VERSION_SERIES.contains(assetIndexName)) {
-				Logging.HTTPD.info("Current version series is " + assetIndexName + ", enable MC-52974 workaround.");
-				enabled = true;
-			}
-		});
-	}
-
-	private static Optional<String> parseArgument(String[] args, String option) {
+	public static Optional<String> inferVersionSeries(String[] args) {
 		boolean hit = false;
 		for (String arg : args) {
 			if (hit) {
@@ -51,10 +48,59 @@ public class MC52974Workaround {
 				}
 			}
 
-			if (option.equals(arg)) {
+			if ("--assetIndex".equals(arg)) {
 				hit = true;
 			}
 		}
 		return Optional.empty();
+	}
+
+	public static void acceptMainArguments(String[] args) {
+		inferVersionSeries(args).ifPresent(assetIndexName -> {
+			if (AFFECTED_VERSION_SERIES.contains(assetIndexName)) {
+				Logging.HTTPD.info("Current version series is " + assetIndexName + ", enable MC-52974 workaround.");
+				affected = true;
+			}
+		});
+	}
+	// ====
+
+	public static boolean overwriteRequireSecure(boolean requireSecure) {
+		if (affected) {
+			return true;
+		}
+		return requireSecure;
+	}
+
+	@Override
+	public Optional<ClassVisitor> transform(ClassLoader classLoader, String className, ClassVisitor writer, Runnable modifiedCallback) {
+		if ("com.mojang.authlib.yggdrasil.YggdrasilMinecraftSessionService".equals(className)) {
+			return Optional.of(new ClassVisitor(ASM7, writer) {
+				@Override
+				public MethodVisitor visitMethod(int access, String name, String descriptor, String signature, String[] exceptions) {
+					if ("fillGameProfile".equals(name) && "(Lcom/mojang/authlib/GameProfile;Z)Lcom/mojang/authlib/GameProfile;".equals(descriptor)) {
+						return new MethodVisitor(ASM7, super.visitMethod(access, name, descriptor, signature, exceptions)) {
+							@Override
+							public void visitCode() {
+								super.visitCode();
+								modifiedCallback.run();
+								super.visitVarInsn(ILOAD, 2);
+								super.visitMethodInsn(INVOKESTATIC, Type.getInternalName(MC52974Workaround.class), "overwriteRequireSecure", "(Z)Z", false);
+								super.visitVarInsn(ISTORE, 2);
+							}
+						};
+					} else {
+						return super.visitMethod(access, name, descriptor, signature, exceptions);
+					}
+				}
+			});
+		} else {
+			return Optional.empty();
+		}
+	}
+
+	@Override
+	public String toString() {
+		return "MC-52974 Workaround";
 	}
 }

--- a/src/main/java/moe/yushi/authlibinjector/transform/support/MC52974Workaround.java
+++ b/src/main/java/moe/yushi/authlibinjector/transform/support/MC52974Workaround.java
@@ -1,0 +1,60 @@
+package moe.yushi.authlibinjector.transform.support;
+
+import static java.util.Collections.unmodifiableSet;
+
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.Optional;
+import java.util.Set;
+
+import moe.yushi.authlibinjector.util.Logging;
+
+/**
+ * See <https://github.com/yushijinhun/authlib-injector/issues/30>
+ */
+public class MC52974Workaround {
+
+	private static final Set<String> AFFECTED_VERSION_SERIES = unmodifiableSet(new HashSet<>(Arrays.asList(
+			"1.7.4", // MC 1.7.9 uses this
+			"1.7.10",
+			"1.8",
+			"1.9",
+			"1.10",
+			"1.11",
+			"1.12")));
+
+	private boolean enabled;
+
+	public boolean needsWorkaround() {
+		return enabled;
+	}
+
+	public void acceptMainArguments(String[] args) {
+		parseArgument(args, "--assetIndex").ifPresent(assetIndexName -> {
+			if (AFFECTED_VERSION_SERIES.contains(assetIndexName)) {
+				Logging.HTTPD.info("Current version series is " + assetIndexName + ", enable MC-52974 workaround.");
+				enabled = true;
+			}
+		});
+	}
+
+	private static Optional<String> parseArgument(String[] args, String option) {
+		boolean hit = false;
+		for (String arg : args) {
+			if (hit) {
+				if (arg.startsWith("--")) {
+					// arg doesn't seem to be a value
+					// maybe the previous argument is a value, but we wrongly recognized it as an option
+					hit = false;
+				} else {
+					return Optional.of(arg);
+				}
+			}
+
+			if (option.equals(arg)) {
+				hit = true;
+			}
+		}
+		return Optional.empty();
+	}
+}

--- a/src/test/java/moe/yushi/authlibinjector/test/MC52974WorkaroundTest.java
+++ b/src/test/java/moe/yushi/authlibinjector/test/MC52974WorkaroundTest.java
@@ -1,0 +1,82 @@
+package moe.yushi.authlibinjector.test;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import org.junit.Test;
+
+import moe.yushi.authlibinjector.transform.support.MC52974Workaround;
+
+public class MC52974WorkaroundTest {
+
+	private boolean checkEnabled(String args) {
+		MC52974Workaround workaround = new MC52974Workaround();
+		workaround.acceptMainArguments(args.split(" "));
+		return workaround.needsWorkaround();
+	}
+
+	@Test
+	public void testNone() {
+		assertFalse(checkEnabled(""));
+	}
+
+	@Test
+	public void testHalf1() {
+		assertFalse(checkEnabled("--assetIndex"));
+	}
+
+	@Test
+	public void testHalf2() {
+		assertFalse(checkEnabled("--width 854 --height 480 --username character2 --version \"HMCL 3.2.SNAPSHOT\" --gameDir /home/yushijinhun/.minecraft --assetsDir /home/yushijinhun/.minecraft/assets --assetIndex"));
+	}
+
+	@Test
+	public void testAmbiguity1() {
+		assertFalse(checkEnabled("--username --assetIndex"));
+	}
+
+	@Test
+	public void testAmbiguity2() {
+		assertTrue(checkEnabled("--demo --assetIndex 1.12"));
+	}
+
+	@Test
+	public void test1_7_9() {
+		assertTrue(checkEnabled("--width 854 --height 480 --username character2 --version \"HMCL 3.2.SNAPSHOT\" --gameDir /home/yushijinhun/.minecraft --assetsDir /home/yushijinhun/.minecraft/assets --assetIndex 1.7.4 --uuid e448fdeff6394b3fac7aecc291446329 --accessToken 65a7fe601b02439fa90bea52b7d46ab5 --userProperties \"{}\" --userType mojang"));
+	}
+
+	@Test
+	public void test1_7_10() {
+		assertTrue(checkEnabled("--width 854 --height 480 --username character2 --version \"HMCL 3.2.SNAPSHOT\" --gameDir /home/yushijinhun/.minecraft --assetsDir /home/yushijinhun/.minecraft/assets --assetIndex 1.7.10 --uuid e448fdeff6394b3fac7aecc291446329 --accessToken 65a7fe601b02439fa90bea52b7d46ab5 --userProperties \"{}\" --userType mojang"));
+	}
+
+	@Test
+	public void test1_8_9() {
+		assertTrue(checkEnabled("--width 854 --height 480 --username character2 --version \"HMCL 3.2.SNAPSHOT\" --gameDir /home/yushijinhun/.minecraft --assetsDir /home/yushijinhun/.minecraft/assets --assetIndex 1.8 --uuid e448fdeff6394b3fac7aecc291446329 --accessToken 65a7fe601b02439fa90bea52b7d46ab5 --userProperties \"{}\" --userType mojang"));
+	}
+
+	@Test
+	public void test1_9_4() {
+		assertTrue(checkEnabled("--width 854 --height 480 --username character2 --version \"HMCL 3.2.SNAPSHOT\" --gameDir /home/yushijinhun/.minecraft --assetsDir /home/yushijinhun/.minecraft/assets --assetIndex 1.9 --uuid e448fdeff6394b3fac7aecc291446329 --accessToken 65a7fe601b02439fa90bea52b7d46ab5 --userType mojang --versionType release"));
+	}
+
+	@Test
+	public void test1_10_2_Forge() {
+		assertTrue(checkEnabled("--width 854 --height 480 --username character2 --version \"HMCL 3.2.SNAPSHOT\" --gameDir /home/yushijinhun/.minecraft --assetsDir /home/yushijinhun/.minecraft/assets --assetIndex 1.10 --uuid e448fdeff6394b3fac7aecc291446329 --accessToken 65a7fe601b02439fa90bea52b7d46ab5 --userType mojang --versionType Forge"));
+	}
+
+	@Test
+	public void test1_11_2() {
+		assertTrue(checkEnabled("--width 854 --height 480 --username character2 --version \"HMCL 3.2.SNAPSHOT\" --gameDir /home/yushijinhun/.minecraft --assetsDir /home/yushijinhun/.minecraft/assets --assetIndex 1.11 --uuid e448fdeff6394b3fac7aecc291446329 --accessToken 65a7fe601b02439fa90bea52b7d46ab5 --userType mojang --versionType release"));
+	}
+
+	@Test
+	public void test1_12_2() {
+		assertTrue(checkEnabled("--width 854 --height 480 --username character2 --version \"HMCL 3.2.SNAPSHOT\" --gameDir /home/yushijinhun/.minecraft --assetsDir /home/yushijinhun/.minecraft/assets --assetIndex 1.12 --uuid e448fdeff6394b3fac7aecc291446329 --accessToken 65a7fe601b02439fa90bea52b7d46ab5 --userType mojang --versionType release"));
+	}
+
+	@Test
+	public void test1_13() {
+		assertFalse(checkEnabled("--username character2 --version \"HMCL 3.2.SNAPSHOT\" --gameDir /home/yushijinhun/.minecraft --assetsDir /home/yushijinhun/.minecraft/assets --assetIndex 1.13 --uuid e448fdeff6394b3fac7aecc291446329 --accessToken 65a7fe601b02439fa90bea52b7d46ab5 --userType mojang --versionType release --width 854 --height 480"));
+	}
+}

--- a/src/test/java/moe/yushi/authlibinjector/test/MC52974WorkaroundTest.java
+++ b/src/test/java/moe/yushi/authlibinjector/test/MC52974WorkaroundTest.java
@@ -1,82 +1,89 @@
 package moe.yushi.authlibinjector.test;
 
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static moe.yushi.authlibinjector.transform.support.MC52974Workaround.inferVersionSeries;
+import static org.junit.Assert.assertEquals;
+
+import java.util.Optional;
 
 import org.junit.Test;
 
-import moe.yushi.authlibinjector.transform.support.MC52974Workaround;
-
 public class MC52974WorkaroundTest {
-
-	private boolean checkEnabled(String args) {
-		MC52974Workaround workaround = new MC52974Workaround();
-		workaround.acceptMainArguments(args.split(" "));
-		return workaround.needsWorkaround();
-	}
 
 	@Test
 	public void testNone() {
-		assertFalse(checkEnabled(""));
+		assertEquals(inferVersionSeries(new String[] {
+				""
+		}), Optional.empty());
 	}
 
 	@Test
 	public void testHalf1() {
-		assertFalse(checkEnabled("--assetIndex"));
+		assertEquals(inferVersionSeries(new String[] {
+				"--assetIndex"
+		}), Optional.empty());
 	}
 
 	@Test
 	public void testHalf2() {
-		assertFalse(checkEnabled("--width 854 --height 480 --username character2 --version \"HMCL 3.2.SNAPSHOT\" --gameDir /home/yushijinhun/.minecraft --assetsDir /home/yushijinhun/.minecraft/assets --assetIndex"));
+		assertEquals(inferVersionSeries(new String[] {
+				"--width",
+				"854",
+				"--height",
+				"480",
+				"--username",
+				"character2",
+				"--version",
+				"HMCL 3.2.SNAPSHOT",
+				"--gameDir",
+				"/home/yushijinhun/.minecraft",
+				"--assetsDir",
+				"/home/yushijinhun/.minecraft/assets",
+				"--assetIndex"
+		}), Optional.empty());
 	}
 
 	@Test
 	public void testAmbiguity1() {
-		assertFalse(checkEnabled("--username --assetIndex"));
+		assertEquals(inferVersionSeries(new String[] {
+				"--username",
+				"--assetIndex"
+		}), Optional.empty());
 	}
 
 	@Test
 	public void testAmbiguity2() {
-		assertTrue(checkEnabled("--demo --assetIndex 1.12"));
-	}
-
-	@Test
-	public void test1_7_9() {
-		assertTrue(checkEnabled("--width 854 --height 480 --username character2 --version \"HMCL 3.2.SNAPSHOT\" --gameDir /home/yushijinhun/.minecraft --assetsDir /home/yushijinhun/.minecraft/assets --assetIndex 1.7.4 --uuid e448fdeff6394b3fac7aecc291446329 --accessToken 65a7fe601b02439fa90bea52b7d46ab5 --userProperties \"{}\" --userType mojang"));
+		assertEquals(inferVersionSeries(new String[] {
+				"--demo",
+				"--assetIndex",
+				"1.12"
+		}), Optional.of("1.12"));
 	}
 
 	@Test
 	public void test1_7_10() {
-		assertTrue(checkEnabled("--width 854 --height 480 --username character2 --version \"HMCL 3.2.SNAPSHOT\" --gameDir /home/yushijinhun/.minecraft --assetsDir /home/yushijinhun/.minecraft/assets --assetIndex 1.7.10 --uuid e448fdeff6394b3fac7aecc291446329 --accessToken 65a7fe601b02439fa90bea52b7d46ab5 --userProperties \"{}\" --userType mojang"));
-	}
-
-	@Test
-	public void test1_8_9() {
-		assertTrue(checkEnabled("--width 854 --height 480 --username character2 --version \"HMCL 3.2.SNAPSHOT\" --gameDir /home/yushijinhun/.minecraft --assetsDir /home/yushijinhun/.minecraft/assets --assetIndex 1.8 --uuid e448fdeff6394b3fac7aecc291446329 --accessToken 65a7fe601b02439fa90bea52b7d46ab5 --userProperties \"{}\" --userType mojang"));
-	}
-
-	@Test
-	public void test1_9_4() {
-		assertTrue(checkEnabled("--width 854 --height 480 --username character2 --version \"HMCL 3.2.SNAPSHOT\" --gameDir /home/yushijinhun/.minecraft --assetsDir /home/yushijinhun/.minecraft/assets --assetIndex 1.9 --uuid e448fdeff6394b3fac7aecc291446329 --accessToken 65a7fe601b02439fa90bea52b7d46ab5 --userType mojang --versionType release"));
-	}
-
-	@Test
-	public void test1_10_2_Forge() {
-		assertTrue(checkEnabled("--width 854 --height 480 --username character2 --version \"HMCL 3.2.SNAPSHOT\" --gameDir /home/yushijinhun/.minecraft --assetsDir /home/yushijinhun/.minecraft/assets --assetIndex 1.10 --uuid e448fdeff6394b3fac7aecc291446329 --accessToken 65a7fe601b02439fa90bea52b7d46ab5 --userType mojang --versionType Forge"));
-	}
-
-	@Test
-	public void test1_11_2() {
-		assertTrue(checkEnabled("--width 854 --height 480 --username character2 --version \"HMCL 3.2.SNAPSHOT\" --gameDir /home/yushijinhun/.minecraft --assetsDir /home/yushijinhun/.minecraft/assets --assetIndex 1.11 --uuid e448fdeff6394b3fac7aecc291446329 --accessToken 65a7fe601b02439fa90bea52b7d46ab5 --userType mojang --versionType release"));
-	}
-
-	@Test
-	public void test1_12_2() {
-		assertTrue(checkEnabled("--width 854 --height 480 --username character2 --version \"HMCL 3.2.SNAPSHOT\" --gameDir /home/yushijinhun/.minecraft --assetsDir /home/yushijinhun/.minecraft/assets --assetIndex 1.12 --uuid e448fdeff6394b3fac7aecc291446329 --accessToken 65a7fe601b02439fa90bea52b7d46ab5 --userType mojang --versionType release"));
-	}
-
-	@Test
-	public void test1_13() {
-		assertFalse(checkEnabled("--username character2 --version \"HMCL 3.2.SNAPSHOT\" --gameDir /home/yushijinhun/.minecraft --assetsDir /home/yushijinhun/.minecraft/assets --assetIndex 1.13 --uuid e448fdeff6394b3fac7aecc291446329 --accessToken 65a7fe601b02439fa90bea52b7d46ab5 --userType mojang --versionType release --width 854 --height 480"));
+		assertEquals(inferVersionSeries(new String[] {
+				"--width",
+				"854",
+				"--height",
+				"480",
+				"--username",
+				"character2",
+				"--version",
+				"HMCL 3.2.SNAPSHOT",
+				"--gameDir",
+				"/home/yushijinhun/.minecraft",
+				"--assetsDir",
+				"/home/yushijinhun/.minecraft/assets",
+				"--assetIndex",
+				"1.7.10",
+				"--uuid",
+				"e448fdeff6394b3fac7aecc291446329",
+				"--accessToken",
+				"65a7fe601b02439fa90bea52b7d46ab5",
+				"--userProperties",
+				"{}",
+				"--userType",
+				"mojang"
+		}), Optional.of("1.7.10"));
 	}
 }


### PR DESCRIPTION
1. 通过强制向 `https://sessionserver.mojang.com/session/minecraft/profile/` 的响应添加数字签名来解决 MC-52974。
2. 只对 1.7.9-1.12.2 系列版本开启这个 workaround。
    1. 通过传入的命令行参数来判定 MC 版本。
    2. 添加 `MainArgumentsTransformer`，用来拦截传入 `main` 的参数。
    3. 使用 `--assetIndex` 参数来判定 MC 版本。
        不使用 `--version` 是因为这个参数的值经常被修改。