### PR TITLE
允许运行时改变材质域名白名单

### DIFF
--- a/src/main/java/moe/yushi/authlibinjector/AuthlibInjector.java
+++ b/src/main/java/moe/yushi/authlibinjector/AuthlibInjector.java
@@ -356,7 +356,8 @@ public final class AuthlibInjector {
 		transformer.units.add(new ConstantURLTransformUnit(urlProcessor));
 		transformer.units.add(new CitizensTransformer());
 
-		transformer.units.add(new SkinWhitelistTransformUnit(config.getSkinDomains().toArray(new String[0])));
+		transformer.units.add(new SkinWhitelistTransformUnit());
+		SkinWhitelistTransformUnit.getWhitelistedDomains().addAll(config.getSkinDomains());
 
 		transformer.units.add(new YggdrasilKeyTransformUnit());
 		config.getDecodedPublickey().ifPresent(YggdrasilKeyTransformUnit.getPublicKeys()::add);


### PR DESCRIPTION
原先 authlib-injector 是通过修改 `<clinit>` 中 `WHITELISTED_DOMAINS` 常量的初始化来实现插入自定义材质域名的。现在我直接 patch 了 `isWhitelistedDomain` 方法，把判断域名是否在白名单中的任务交给了 authlib-injector。这样我就可以在运行时改变材质域名白名单，为以后的热加载做准备。