### PR TITLE
实现 #41

### DIFF
--- a/src/main/java/moe/yushi/authlibinjector/InjectorInitializationException.java
+++ b/src/main/java/moe/yushi/authlibinjector/InjectorInitializationException.java
@@ -21,14 +21,6 @@ public class InjectorInitializationException extends RuntimeException {
 	public InjectorInitializationException() {
 	}
 
-	public InjectorInitializationException(String message, Throwable cause) {
-		super(message, cause);
-	}
-
-	public InjectorInitializationException(String message) {
-		super(message);
-	}
-
 	public InjectorInitializationException(Throwable cause) {
 		super(cause);
 	}

--- a/src/main/java/moe/yushi/authlibinjector/httpd/LegacySkinAPIFilter.java
+++ b/src/main/java/moe/yushi/authlibinjector/httpd/LegacySkinAPIFilter.java
@@ -20,7 +20,7 @@ import static java.util.Optional.empty;
 import static java.util.Optional.of;
 import static java.util.Optional.ofNullable;
 import static moe.yushi.authlibinjector.util.IOUtils.asString;
-import static moe.yushi.authlibinjector.util.IOUtils.getURL;
+import static moe.yushi.authlibinjector.util.IOUtils.http;
 import static moe.yushi.authlibinjector.util.IOUtils.newUncheckedIOException;
 import static moe.yushi.authlibinjector.util.JsonUtils.asJsonObject;
 import static moe.yushi.authlibinjector.util.JsonUtils.parseJson;
@@ -81,7 +81,7 @@ public class LegacySkinAPIFilter implements URLFilter {
 			Logging.HTTPD.fine("Retrieving skin for " + username + " from " + url);
 			byte[] data;
 			try {
-				data = getURL(url);
+				data = http("GET", url);
 			} catch (IOException e) {
 				throw newUncheckedIOException("Failed to retrieve skin from " + url, e);
 			}

--- a/src/main/java/moe/yushi/authlibinjector/yggdrasil/YggdrasilClient.java
+++ b/src/main/java/moe/yushi/authlibinjector/yggdrasil/YggdrasilClient.java
@@ -20,9 +20,8 @@ import static java.nio.charset.StandardCharsets.UTF_8;
 import static java.util.Collections.singleton;
 import static moe.yushi.authlibinjector.util.IOUtils.CONTENT_TYPE_JSON;
 import static moe.yushi.authlibinjector.util.IOUtils.asString;
-import static moe.yushi.authlibinjector.util.IOUtils.getURL;
+import static moe.yushi.authlibinjector.util.IOUtils.http;
 import static moe.yushi.authlibinjector.util.IOUtils.newUncheckedIOException;
-import static moe.yushi.authlibinjector.util.IOUtils.postURL;
 import static moe.yushi.authlibinjector.util.JsonUtils.asJsonArray;
 import static moe.yushi.authlibinjector.util.JsonUtils.asJsonObject;
 import static moe.yushi.authlibinjector.util.JsonUtils.asJsonString;
@@ -31,6 +30,7 @@ import static moe.yushi.authlibinjector.util.UUIDUtils.fromUnsignedUUID;
 
 import java.io.IOException;
 import java.io.UncheckedIOException;
+import java.net.Proxy;
 import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Optional;
@@ -45,17 +45,23 @@ import moe.yushi.authlibinjector.yggdrasil.GameProfile.PropertyValue;
 public class YggdrasilClient {
 
 	private YggdrasilAPIProvider apiProvider;
+	private Proxy proxy;
 
 	public YggdrasilClient(YggdrasilAPIProvider apiProvider) {
+		this(apiProvider, null);
+	}
+
+	public YggdrasilClient(YggdrasilAPIProvider apiProvider, Proxy proxy) {
 		this.apiProvider = apiProvider;
+		this.proxy = proxy;
 	}
 
 	public Map<String, UUID> queryUUIDs(Set<String> names) throws UncheckedIOException {
 		String responseText;
 		try {
-			responseText = asString(postURL(
-					apiProvider.queryUUIDsByNames(), CONTENT_TYPE_JSON,
-					JSONArray.toJSONString(names).getBytes(UTF_8)));
+			responseText = asString(http("POST", apiProvider.queryUUIDsByNames(),
+					JSONArray.toJSONString(names).getBytes(UTF_8), CONTENT_TYPE_JSON,
+					proxy));
 		} catch (IOException e) {
 			throw new UncheckedIOException(e);
 		}
@@ -82,7 +88,7 @@ public class YggdrasilClient {
 		}
 		String responseText;
 		try {
-			responseText = asString(getURL(url));
+			responseText = asString(http("GET", url, proxy));
 		} catch (IOException e) {
 			throw new UncheckedIOException(e);
 		}


### PR DESCRIPTION
* 通过 `-Dauthlibinjector.mojang.proxy=socks://<host>:<port>` 参数来指定代理。
    * 目前仅支持 SOCKS5。
* 只有查询带 `@mojang` 后缀的角色的属性时，才会走代理。材质图像下载不走代理（即使是来自Mojang的材质）。
* 这一功能的适用场景是 MC 服务端要挂代理才能访问 Mojang。