### PR TITLE
修复与 --proxyHost 冲突

### DIFF
--- a/src/main/java/moe/yushi/authlibinjector/AuthlibInjector.java
+++ b/src/main/java/moe/yushi/authlibinjector/AuthlibInjector.java
@@ -56,6 +56,7 @@ import moe.yushi.authlibinjector.transform.support.ConstantURLTransformUnit;
 import moe.yushi.authlibinjector.transform.support.MC52974Workaround;
 import moe.yushi.authlibinjector.transform.support.MC52974_1710Workaround;
 import moe.yushi.authlibinjector.transform.support.MainArgumentsTransformer;
+import moe.yushi.authlibinjector.transform.support.ProxyParameterWorkaround;
 import moe.yushi.authlibinjector.transform.support.SkinWhitelistTransformUnit;
 import moe.yushi.authlibinjector.transform.support.YggdrasilKeyTransformUnit;
 import moe.yushi.authlibinjector.yggdrasil.CustomYggdrasilAPIProvider;
@@ -90,6 +91,7 @@ public final class AuthlibInjector {
 		classTransformer = createTransformer(apiMetadata);
 		instrumentation.addTransformer(classTransformer, retransformSupported);
 
+		ProxyParameterWorkaround.init();
 		MC52974Workaround.init();
 		MC52974_1710Workaround.init();
 	}

--- a/src/main/java/moe/yushi/authlibinjector/transform/support/MainArgumentsTransformer.java
+++ b/src/main/java/moe/yushi/authlibinjector/transform/support/MainArgumentsTransformer.java
@@ -75,12 +75,13 @@ public class MainArgumentsTransformer implements TransformUnit {
 
 	@CallbackMethod
 	public static String[] processMainArguments(String[] args) {
-		log(DEBUG, "Main arguments: " + Stream.of(args).collect(joining(" ")));
+		log(DEBUG, "Original main arguments: " + Stream.of(args).collect(joining(" ")));
 
 		String[] result = args;
 		for (Function<String[], String[]> listener : ARGUMENTS_LISTENERS) {
 			result = listener.apply(result);
 		}
+		log(DEBUG, "Transformed main arguments: " + Stream.of(result).collect(joining(" ")));
 		return result;
 	}
 

--- a/src/main/java/moe/yushi/authlibinjector/transform/support/ProxyParameterWorkaround.java
+++ b/src/main/java/moe/yushi/authlibinjector/transform/support/ProxyParameterWorkaround.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright (C) 2020  Haowei Wen <yushijinhun@gmail.com> and contributors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package moe.yushi.authlibinjector.transform.support;
+
+import static moe.yushi.authlibinjector.util.Logging.log;
+import static moe.yushi.authlibinjector.util.Logging.Level.WARNING;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+public final class ProxyParameterWorkaround {
+	private ProxyParameterWorkaround() {}
+
+	private static final Set<String> PROXY_PARAMETERS = new HashSet<>(Arrays.asList(
+			"--proxyHost", "--proxyPort", "--proxyUser", "--proxyPass"
+	));
+
+	public static void init() {
+		MainArgumentsTransformer.getArgumentsListeners().add(args -> {
+			boolean proxyDetected = false;
+			List<String> filtered = new ArrayList<>();
+			for (int i = 0; i < args.length; i++) {
+				if (i + 1 < args.length && PROXY_PARAMETERS.contains(args[i])) {
+					proxyDetected = true;
+					log(WARNING, "Dropping main argument " + args[i] + " " + args[i + 1]);
+					i++;
+					continue;
+				}
+				filtered.add(args[i]);
+			}
+			if (proxyDetected) {
+				log(WARNING, "--proxyHost parameter conflicts with authlib-injector, therefore proxy is disabled.");
+			}
+			return filtered.toArray(new String[filtered.size()]);
+		});
+	}
+}


### PR DESCRIPTION
## 问题概述
若在 MC 客户端使用 `--proxyHost`、`--proxyPort` 参数指定 SOCKS 代理，则 authlib 访问环回地址时**不会绕过代理**，进而导致 authlib-injector 不可用。故障表现为，进服时报错 _Failed to log in: The authentication servers are currently down for maintenance._，客户端日志报错 _java.net.SocketException: Unexpected end of file from server_。

在原版 MC 中，`--proxyHost`、`--proxyPort`、`--proxyUser` 和 `--proxyPass` 这几个参数用于设置访问 Mojang 验证服务所使用的代理，其**仅在** authlib 中使用（具体来说，代理设置会被传入 [YggdrasilAuthenticationService](https://gitlab.com/yushijinhun/authlib-history/-/blob/07305dd53fb221ecf6935ce1a9b7d63fa3940489/com/mojang/authlib/yggdrasil/YggdrasilAuthenticationService.java#L45)），**不用于**其他网络请求，**亦不用于**多人联机。由于这个代理设置是直接传入 [URL.openConnection(Proxy)](https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/net/URL.html#openConnection(java.net.Proxy)) 方法的，因此不会绕行环回地址。

据目前所知，会设置这一参数的启动器仅有 HMCL。如果用户在 HMCL 中开启了 SOCKS 代理，那么 HMCL 就会向游戏添加 `--proxyHost` 和 `--proxyPort` 参数。如果用户同时使用 authlib-injector，就会出现上述故障。

## 修复方案
如果启动参数包含 `--proxyHost`、`--proxyPort`、`--proxyUser` 或 `--proxyPass`，则将其移除，并打印警告，告知用户 authlib-injector 不兼容 `--proxyHost` 等参数。

以下是我选择这一方案的原因：

由于 `--proxyHost` 等参数设置的代理仅供 authlib 使用，可以推测其在原版 MC 中的使用场景为：通过代理解决连接 Mojang 验证服务不稳定的问题。而在使用 authlib-injector 时，我们连接的是第三方验证服务，而不是 Mojang 验证服务，因此我们大概率不会有这个需求。
