### PR TITLE
新的 skinDomains 匹配方法

### DIFF
--- a/src/main/java/moe/yushi/authlibinjector/transform/support/SkinWhitelistTransformUnit.java
+++ b/src/main/java/moe/yushi/authlibinjector/transform/support/SkinWhitelistTransformUnit.java
@@ -19,22 +19,31 @@ package moe.yushi.authlibinjector.transform.support;
 import static org.objectweb.asm.Opcodes.ALOAD;
 import static org.objectweb.asm.Opcodes.ASM7;
 import static org.objectweb.asm.Opcodes.IRETURN;
-
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.util.List;
 import java.util.Optional;
 import java.util.concurrent.CopyOnWriteArrayList;
-
 import org.objectweb.asm.ClassVisitor;
 import org.objectweb.asm.MethodVisitor;
-
 import moe.yushi.authlibinjector.transform.CallbackMethod;
 import moe.yushi.authlibinjector.transform.CallbackSupport;
 import moe.yushi.authlibinjector.transform.TransformContext;
 import moe.yushi.authlibinjector.transform.TransformUnit;
 
 public class SkinWhitelistTransformUnit implements TransformUnit {
+
+	public static boolean domainMatches(String pattern, String domain) {
+		// for security concern, empty pattern matches nothing
+		if (pattern.isEmpty()) {
+			return false;
+		}
+		if (pattern.startsWith(".")) {
+			return domain.endsWith(pattern);
+		} else {
+			return domain.equals(pattern);
+		}
+	}
 
 	private static final String[] DEFAULT_WHITELISTED_DOMAINS = {
 			".minecraft.net",
@@ -56,13 +65,13 @@ public class SkinWhitelistTransformUnit implements TransformUnit {
 			throw new IllegalArgumentException("Invalid URL '" + url + "'");
 		}
 
-		for (String whitelisted : DEFAULT_WHITELISTED_DOMAINS) {
-			if (domain.endsWith(whitelisted)) {
+		for (String pattern : DEFAULT_WHITELISTED_DOMAINS) {
+			if (domainMatches(pattern, domain)) {
 				return true;
 			}
 		}
-		for (String whitelisted : WHITELISTED_DOMAINS) {
-			if (domain.endsWith(whitelisted)) {
+		for (String pattern : WHITELISTED_DOMAINS) {
+			if (domainMatches(pattern, domain)) {
 				return true;
 			}
 		}

--- a/src/test/java/moe/yushi/authlibinjector/test/SkinWhitelistTest.java
+++ b/src/test/java/moe/yushi/authlibinjector/test/SkinWhitelistTest.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright (C) 2020  Haowei Wen <yushijinhun@gmail.com> and contributors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package moe.yushi.authlibinjector.test;
+
+import static moe.yushi.authlibinjector.transform.support.SkinWhitelistTransformUnit.domainMatches;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import org.junit.Test;
+
+public class SkinWhitelistTest {
+
+	@Test
+	public void testEmptyPattern() {
+		assertFalse(domainMatches("", "example.com"));
+	}
+
+	@Test
+	public void testDotMatchesSubdomain() {
+		assertTrue(domainMatches(".example.com", "a.example.com"));
+	}
+
+	@Test
+	public void testDotMatchesSubdomain2() {
+		assertTrue(domainMatches(".example.com", "b.a.example.com"));
+	}
+
+	@Test
+	public void testDotNotMatchesToplevel() {
+		assertFalse(domainMatches(".example.com", "example.com"));
+	}
+
+	@Test
+	public void testNonDotMatchesToplevel() {
+		assertTrue(domainMatches("example.com", "example.com"));
+	}
+
+	@Test
+	public void testNonDotNotMatchesSubdomain() {
+		assertFalse(domainMatches("example.com", "a.example.com"));
+	}
+
+	@Test
+	public void testNonDotNotMatchesOther() {
+		assertFalse(domainMatches("example.com", "eexample.com"));
+	}
+}


### PR DESCRIPTION
此 PR 使用了新的 skinDomains 匹配方法，以规避原先方法可能带来的安全问题。

## 问题背景
[API 元数据](https://github.com/yushijinhun/authlib-injector/wiki/Yggdrasil-%E6%9C%8D%E5%8A%A1%E7%AB%AF%E6%8A%80%E6%9C%AF%E8%A7%84%E8%8C%83#api-%E5%85%83%E6%95%B0%E6%8D%AE%E8%8E%B7%E5%8F%96) 中包含了一项名为 `skinDomains` 的属性，即材质白名单。仅当材质 URL 的域名匹配白名单中的规则时，Minecraft 才会下载这一材质。引入这一机制的原因见 [MC-78491](https://bugs.mojang.com/browse/MC-78491)。

目前，authlib-injector 使用的匹配方法沿用自原版 MC，具体为：材质域名须以白名单中的任意一项结尾。例如：
* `.example.com` **匹配** `a.example.com`、`b.a.example.com`，**不匹配** `example.com`。
* `example.com` **匹配** `example.com`、`a.example.com`、**`eexample.com`**。

如果您要匹配 `example.com` 下的子域名，您可以使用 `.example.com` 规则，这并无问题；但若您要匹配 `example.com` 这个顶级域名，您就必须使用 `example.com` 规则，**但 `example.com` 与此同时也会匹配 `eexample.com`，而这就造成了潜在的安全问题**。

## 解决方法
将 `skinDomains` 的匹配方法修改为如下：
* 如果规则以 `.` (dot) 开头，则匹配以这一规则结尾的域名。
  * 例如 `.example.com` 匹配 `a.example.com`、`b.a.example.com`，不匹配 `example.com`。
  * 这与先前无异。
* 如果规则**不以** `.` (dot) 开头，则匹配的域名须与规则**完全相同**。
  * 例如 `example.com` 匹配 `example.com`，**不匹配** `a.example.com`、`eexample.com`。

## 兼容性
由于新的匹配方法更为严格，因此可能造成兼容性问题。

如果您使用单条规则（如 `example.com`）去同时匹配某个域名（如 `example.com`）及其下的子域名（如 `a.example.com`），这将不再有效。您需要使用 `example.com`（匹配顶级域名）和 `.example.com`（匹配子域名）两条规则。
