### PR TITLE
Release 1.1.34

### DIFF
--- a/.github/workflows/deploy_release.yml
+++ b/.github/workflows/deploy_release.yml
@@ -70,7 +70,7 @@ jobs:
                   "version": .version
                 }' < "$file"
             fi
-          done | jq -s '
+          done | jq -s 'sort_by(.build_number)|reverse|
             {
               "latest_build_number": max_by(.build_number).build_number,
               "artifacts": .

--- a/README.en.md
+++ b/README.en.md
@@ -76,4 +76,9 @@ Configure Minecraft server with the following JVM parameter:
     Features (see below) depending on local HTTP server will be unavailable:
      - Mojang namespace
      - Legacy skin API polyfill
+
+-Dauthlibinjector.noShowServerName
+    Do not show authentication server name in Minecraft menu screen.
+    By default, authlib-injector alters --versionType parameter to display the authentication server name.
+    This feature can be disabled using this option.
 ```

--- a/README.en.md
+++ b/README.en.md
@@ -53,6 +53,9 @@ Configure Minecraft server with the following JVM parameter:
     Only SOCKS protocol is supported.
     URL format: socks://<host>:<port>
 
+    This proxy setting only affects Mojang namespace feature, and the proxy is used only when accessing Mojang's servers.
+    To enable proxy for your customized authentication server, see https://docs.oracle.com/javase/8/docs/technotes/guides/net/proxies.html .
+
 -Dauthlibinjector.legacySkinPolyfill={default|enabled|disabled}
     Whether to polyfill legacy skin API, namely 'GET /skins/MinecraftSkins/{username}.png'.
     It's enabled by default if the authentication server does NOT send feature.legacy_skin_api option.

--- a/README.md
+++ b/README.md
@@ -75,6 +75,10 @@ gradle
     以下依赖内建 HTTP 服务器的功能将不可用:
      - Mojang 命名空间
      - 旧式皮肤 API polyfill
+
+-Dauthlibinjector.noShowServerName
+    不要在 Minecraft 主界面展示验证服务器名称.
+    默认情况下, authlib-injector 通过更改 --versionType 参数来在 Minecraft 主界面显示验证服务器名称, 使用本选项可以禁用该功能.
 ```
 
 ## 捐助

--- a/README.md
+++ b/README.md
@@ -52,6 +52,9 @@ gradle
     设置访问 Mojang 验证服务时使用的代理, 目前仅支持 SOCKS 协议.
     URL 格式: socks://<host>:<port>
 
+    这一代理仅作用于 Mojang 命名空间 功能, 其仅用于访问 Mojang 服务器.
+    若要在访问自定义验证服务器时使用代理, 请参考 https://docs.oracle.com/javase/8/docs/technotes/guides/net/proxies.html .
+
 -Dauthlibinjector.legacySkinPolyfill={default|enabled|disabled}
     是否启用旧式皮肤 API polyfill, 即 'GET /skins/MinecraftSkins/{username}.png'.
     若验证服务器未设置 feature.legacy_skin_api 选项, 则该功能默认启用.

--- a/src/main/java/moe/yushi/authlibinjector/AuthlibInjector.java
+++ b/src/main/java/moe/yushi/authlibinjector/AuthlibInjector.java
@@ -50,6 +50,7 @@ import moe.yushi.authlibinjector.httpd.URLFilter;
 import moe.yushi.authlibinjector.httpd.URLProcessor;
 import moe.yushi.authlibinjector.transform.ClassTransformer;
 import moe.yushi.authlibinjector.transform.DumpClassListener;
+import moe.yushi.authlibinjector.transform.support.AuthServerNameInjector;
 import moe.yushi.authlibinjector.transform.support.AuthlibLogInterceptor;
 import moe.yushi.authlibinjector.transform.support.CitizensTransformer;
 import moe.yushi.authlibinjector.transform.support.ConstantURLTransformUnit;
@@ -94,6 +95,9 @@ public final class AuthlibInjector {
 		ProxyParameterWorkaround.init();
 		MC52974Workaround.init();
 		MC52974_1710Workaround.init();
+		if (!Config.noShowServerName) {
+			AuthServerNameInjector.init(apiMetadata);
+		}
 	}
 
 	private static Optional<String> getPrefetchedResponse() {

--- a/src/main/java/moe/yushi/authlibinjector/Config.java
+++ b/src/main/java/moe/yushi/authlibinjector/Config.java
@@ -59,6 +59,7 @@ public final class Config {
 	public static Set<String> ignoredPackages;
 	public static FeatureOption mojangNamespace;
 	public static FeatureOption legacySkinPolyfill;
+	public static boolean noShowServerName;
 
 	private static void initDebugOptions() {
 		String prop = System.getProperty("authlibinjector.debug");
@@ -202,5 +203,6 @@ public final class Config {
 		mojangNamespace = parseFeatureOption("authlibinjector.mojangNamespace");
 		legacySkinPolyfill = parseFeatureOption("authlibinjector.legacySkinPolyfill");
 		httpdDisabled = System.getProperty("authlibinjector.disableHttpd") != null;
+		noShowServerName = System.getProperty("authlibinjector.noShowServerName") != null;
 	}
 }

--- a/src/main/java/moe/yushi/authlibinjector/transform/support/AuthServerNameInjector.java
+++ b/src/main/java/moe/yushi/authlibinjector/transform/support/AuthServerNameInjector.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright (C) 2020  Haowei Wen <yushijinhun@gmail.com> and contributors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package moe.yushi.authlibinjector.transform.support;
+
+import static moe.yushi.authlibinjector.util.Logging.log;
+import moe.yushi.authlibinjector.APIMetadata;
+import moe.yushi.authlibinjector.util.Logging.Level;
+
+public final class AuthServerNameInjector {
+	private AuthServerNameInjector() {}
+
+	private static String getServerName(APIMetadata meta) {
+		Object serverName = meta.getMeta().get("serverName");
+		if (serverName instanceof String) {
+			return (String) serverName;
+		} else {
+			return meta.getApiRoot();
+		}
+	}
+
+	public static void init(APIMetadata meta) {
+		MainArgumentsTransformer.getArgumentsListeners().add(args -> {
+			for (int i = 0; i < args.length - 1; i++) {
+				if ("--versionType".equals(args[i])) {
+					String serverName = getServerName(meta);
+					log(Level.DEBUG, "Setting versionType to server name: " + serverName);
+					args[i + 1] = serverName;
+					break;
+				}
+			}
+			return args;
+		});
+	}
+
+}


### PR DESCRIPTION
# Changes
<!--changes_begin-->
* [Fix] **[Security]** 修复材质白名单可能匹配意料之外的域名 (#91)
* [Feature] 在 Minecraft 主菜单显示验证服务器名称
  * 此功能可以通过 `-Dauthlibinjector.noShowServerName` 禁用
<!--changes_end-->

<!--@@release_proposal.version_number=1.1.34@@-->