### PR TITLE
Intercept requests to api.minecraftservices.com

### DIFF
--- a/src/main/java/moe/yushi/authlibinjector/AuthlibInjector.java
+++ b/src/main/java/moe/yushi/authlibinjector/AuthlibInjector.java
@@ -44,6 +44,7 @@ import java.util.Set;
 import java.util.stream.Stream;
 import moe.yushi.authlibinjector.httpd.DefaultURLRedirector;
 import moe.yushi.authlibinjector.httpd.LegacySkinAPIFilter;
+import moe.yushi.authlibinjector.httpd.PrivilegesFilter;
 import moe.yushi.authlibinjector.httpd.QueryProfileFilter;
 import moe.yushi.authlibinjector.httpd.QueryUUIDsFilter;
 import moe.yushi.authlibinjector.httpd.URLFilter;
@@ -237,6 +238,12 @@ public final class AuthlibInjector {
 			filters.add(new QueryProfileFilter(mojangClient, customClient));
 		} else {
 			log(INFO, "Disabled Mojang namespace");
+		}
+
+		boolean polyfillPrivilegesApi = !Boolean.TRUE.equals(config.getMeta().get("feature.privileges_api"));
+		if (polyfillPrivilegesApi) {
+			log(INFO, "Polyfill privileges API");
+			filters.add(new PrivilegesFilter());
 		}
 
 		return filters;

--- a/src/main/java/moe/yushi/authlibinjector/httpd/DefaultURLRedirector.java
+++ b/src/main/java/moe/yushi/authlibinjector/httpd/DefaultURLRedirector.java
@@ -37,6 +37,7 @@ public class DefaultURLRedirector implements URLRedirector {
 		domainMapping.put("authserver.mojang.com", "authserver");
 		domainMapping.put("sessionserver.mojang.com", "sessionserver");
 		domainMapping.put("skins.minecraft.net", "skins");
+		domainMapping.put("api.minecraftservices.com", "minecraftservices");
 	}
 
 	@Override

--- a/src/main/java/moe/yushi/authlibinjector/httpd/PrivilegesFilter.java
+++ b/src/main/java/moe/yushi/authlibinjector/httpd/PrivilegesFilter.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright (C) 2020  Haowei Wen <yushijinhun@gmail.com> and contributors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package moe.yushi.authlibinjector.httpd;
+
+import static moe.yushi.authlibinjector.util.IOUtils.CONTENT_TYPE_JSON;
+import java.io.IOException;
+import java.util.Optional;
+import moe.yushi.authlibinjector.internal.fi.iki.elonen.IHTTPSession;
+import moe.yushi.authlibinjector.internal.fi.iki.elonen.Response;
+import moe.yushi.authlibinjector.internal.fi.iki.elonen.Status;
+import moe.yushi.authlibinjector.internal.org.json.simple.JSONObject;
+
+public class PrivilegesFilter implements URLFilter {
+
+	private static final String[] PRIVILEGES = { "onlineChat", "multiplayerServer", "multiplayerRealms" };
+
+	@Override
+	public boolean canHandle(String domain) {
+		return domain.equals("api.minecraftservices.com");
+	}
+
+	@Override
+	public Optional<Response> handle(String domain, String path, IHTTPSession session) throws IOException {
+		if (domain.equals("api.minecraftservices.com") && path.equals("/privileges") && session.getMethod().equals("GET")) {
+			JSONObject response = new JSONObject();
+			JSONObject privileges = new JSONObject();
+			for (String privilegeName : PRIVILEGES) {
+				JSONObject privilege = new JSONObject();
+				privilege.put("enabled", true);
+				privileges.put(privilegeName, privilege);
+			}
+			response.put("privileges", privileges);
+			return Optional.of(Response.newFixedLength(Status.OK, CONTENT_TYPE_JSON, response.toJSONString()));
+		} else {
+			return Optional.empty();
+		}
+	}
+}


### PR DESCRIPTION
* All requests to `api.minecraftservices.com` are now intercepted.
* Unless authentication server sets `feature.privileges_api` flag to true, request to `api.minecraftservices.com/privileges` will be handled locally.
  * The request is responded with content:
    ```json
    {
        "onlineChat": { "enabled": true },
        "multiplayerServer": { "enabled": true },
        "multiplayerRealms": { "enabled": true },
        "telemetry": { "enabled": false }
    }
    ```
* Will slightly improve Minecraft startup speed.