### PR TITLE
add BungeeCordTransformer

### DIFF
--- a/src/main/java/moe/yushi/authlibinjector/AuthlibInjector.java
+++ b/src/main/java/moe/yushi/authlibinjector/AuthlibInjector.java
@@ -51,17 +51,7 @@ import moe.yushi.authlibinjector.httpd.URLFilter;
 import moe.yushi.authlibinjector.httpd.URLProcessor;
 import moe.yushi.authlibinjector.transform.ClassTransformer;
 import moe.yushi.authlibinjector.transform.DumpClassListener;
-import moe.yushi.authlibinjector.transform.support.AuthServerNameInjector;
-import moe.yushi.authlibinjector.transform.support.AuthlibLogInterceptor;
-import moe.yushi.authlibinjector.transform.support.CitizensTransformer;
-import moe.yushi.authlibinjector.transform.support.ConcatenateURLTransformUnit;
-import moe.yushi.authlibinjector.transform.support.ConstantURLTransformUnit;
-import moe.yushi.authlibinjector.transform.support.MC52974Workaround;
-import moe.yushi.authlibinjector.transform.support.MC52974_1710Workaround;
-import moe.yushi.authlibinjector.transform.support.MainArgumentsTransformer;
-import moe.yushi.authlibinjector.transform.support.ProxyParameterWorkaround;
-import moe.yushi.authlibinjector.transform.support.SkinWhitelistTransformUnit;
-import moe.yushi.authlibinjector.transform.support.YggdrasilKeyTransformUnit;
+import moe.yushi.authlibinjector.transform.support.*;
 import moe.yushi.authlibinjector.yggdrasil.CustomYggdrasilAPIProvider;
 import moe.yushi.authlibinjector.yggdrasil.MojangYggdrasilAPIProvider;
 import moe.yushi.authlibinjector.yggdrasil.YggdrasilClient;
@@ -269,6 +259,9 @@ public final class AuthlibInjector {
 		SkinWhitelistTransformUnit.getWhitelistedDomains().addAll(config.getSkinDomains());
 
 		transformer.units.add(new YggdrasilKeyTransformUnit());
+
+		transformer.units.add(new BungeeCordTransformer());
+
 		config.getDecodedPublickey().ifPresent(YggdrasilKeyTransformUnit.PUBLIC_KEYS::add);
 
 		return transformer;

--- a/src/main/java/moe/yushi/authlibinjector/transform/support/BungeeCordTransformer.java
+++ b/src/main/java/moe/yushi/authlibinjector/transform/support/BungeeCordTransformer.java
@@ -1,0 +1,80 @@
+package moe.yushi.authlibinjector.transform.support;
+
+import moe.yushi.authlibinjector.transform.TransformContext;
+import moe.yushi.authlibinjector.transform.TransformUnit;
+import org.objectweb.asm.ClassVisitor;
+import org.objectweb.asm.ClassWriter;
+import org.objectweb.asm.Label;
+import org.objectweb.asm.MethodVisitor;
+
+import java.util.Optional;
+
+import static org.objectweb.asm.Opcodes.*;
+
+/**
+ * Support for BungeeCord and downstream branches
+ * <p>
+ * BungeeCord limited the player name character in <https://github.com/SpigotMC/BungeeCord/blob/c7b0c3cd48c9929c6ba41ff333727adba89b4e07/proxy/src/main/java/net/md_5/bungee/util/AllowedCharacters.java#L28>
+ * caused all non-ASCII characters profile can not join the server.
+ * This class is used to replace the original method to allow all characters in offline mode.
+ */
+public class BungeeCordTransformer implements TransformUnit {
+
+    @Override
+    public Optional<ClassVisitor> transform(ClassLoader classLoader, String className, ClassVisitor writer, TransformContext context) {
+        if ("net.md_5.bungee.util.AllowedCharacters".equals(className)) {
+            return Optional.of(new ClassVisitor(ASM9, writer) {
+                @Override
+                public MethodVisitor visitMethod(int access, String name, String descriptor, String signature, String[] exceptions) {
+                    // private static boolean isNameAllowedCharacter(char c, boolean onlineMode)
+                    if ("isNameAllowedCharacter".equals(name) && "(CZ)Z".equals(descriptor)) {
+                        return new MethodVisitor(ASM9, new ClassWriter(ClassWriter.COMPUTE_FRAMES).visitMethod(access, name, descriptor, signature, exceptions)) {
+                            @Override
+                            public void visitCode() {
+                                // return isChatAllowedCharacter( c ) && c != ' ';
+                                super.visitCode();
+                                // ILOAD c
+                                super.visitVarInsn(ILOAD, 0);
+                                // INVOKESTATIC net/md_5/bungee/util/AllowedCharacters.isChatAllowedCharacter(C)Z
+                                super.visitMethodInsn(INVOKESTATIC, "net/md_5/bungee/util/AllowedCharacters", "isChatAllowedCharacter", "(C)Z", false);
+                                // IFEQ J
+                                Label falseLabel = new Label();
+                                super.visitJumpInsn(IFEQ, falseLabel);
+                                // ILOAD c
+                                super.visitVarInsn(ILOAD, 0);
+                                // BIPUSH 32
+                                super.visitVarInsn(BIPUSH, 32);
+                                // IF_ICMPEQ J
+                                super.visitJumpInsn(IFEQ, falseLabel);
+                                // ICONST_1
+                                super.visitInsn(ICONST_1);
+                                // GOTO K
+                                Label returnLabel = new Label();
+                                super.visitJumpInsn(GOTO, returnLabel);
+                                // J:
+                                super.visitLabel(falseLabel);
+                                // ICONST_0
+                                super.visitInsn(ICONST_0);
+                                // K:
+                                super.visitLabel(returnLabel);
+                                // IRETURN
+                                super.visitInsn(IRETURN);
+
+                                super.visitEnd();
+
+                                context.markModified();
+                            }
+                        };
+                    }
+                    return super.visitMethod(access, name, descriptor, signature, exceptions);
+                }
+            });
+        }
+        return Optional.empty();
+    }
+
+    @Override
+    public String toString() {
+        return "BungeeCord Support";
+    }
+}


### PR DESCRIPTION
BungeeCord limited the player name character in <https://github.com/SpigotMC/BungeeCord/blob/c7b0c3cd48c9929c6ba41ff333727adba89b4e07/proxy/src/main/java/net/md_5/bungee/util/AllowedCharacters.java#L28> caused all non-ASCII characters profile can not join the server. 

This class is used to replace the original method to allow all characters in offline mode.

**Known Issues:**
- ArrayOutOfBoundsException throwed when player join server casued frames compute, stacktrace:
```
java.lang.ArrayIndexOutOfBoundsException: 0
	at moe.yushi.authlibinjector.internal.org.objectweb.asm.Frame.merge(Frame.java:1268)
	at moe.yushi.authlibinjector.internal.org.objectweb.asm.Frame.merge(Frame.java:1244)
	at moe.yushi.authlibinjector.internal.org.objectweb.asm.MethodWriter.computeAllFrames(MethodWriter.java:1610)
	at moe.yushi.authlibinjector.internal.org.objectweb.asm.MethodWriter.visitMaxs(MethodWriter.java:1546)
	at moe.yushi.authlibinjector.internal.org.objectweb.asm.MethodVisitor.visitMaxs(MethodVisitor.java:773)
	at moe.yushi.authlibinjector.internal.org.objectweb.asm.ClassReader.readCode(ClassReader.java:2665)
	at moe.yushi.authlibinjector.internal.org.objectweb.asm.ClassReader.readMethod(ClassReader.java:1514)
	at moe.yushi.authlibinjector.internal.org.objectweb.asm.ClassReader.accept(ClassReader.java:744)
	at moe.yushi.authlibinjector.internal.org.objectweb.asm.ClassReader.accept(ClassReader.java:424)
	at moe.yushi.authlibinjector.transform.ClassTransformer$TransformHandle.accept(ClassTransformer.java:118)
	at java.util.concurrent.CopyOnWriteArrayList.forEach(Unknown Source)
	at moe.yushi.authlibinjector.transform.ClassTransformer.transform(ClassTransformer.java:180)
	at sun.instrument.TransformerManager.transform(Unknown Source)
	at sun.instrument.InstrumentationImpl.transform(Unknown Source)
	at java.lang.ClassLoader.defineClass1(Native Method)
	at java.lang.ClassLoader.defineClass(Unknown Source)
	at java.security.SecureClassLoader.defineClass(Unknown Source)
	at java.net.URLClassLoader.defineClass(Unknown Source)
	at java.net.URLClassLoader.access$100(Unknown Source)
	at java.net.URLClassLoader$1.run(Unknown Source)
	at java.net.URLClassLoader$1.run(Unknown Source)
	at java.security.AccessController.doPrivileged(Native Method)
	at java.net.URLClassLoader.findClass(Unknown Source)
	at java.lang.ClassLoader.loadClass(Unknown Source)
	at sun.misc.Launcher$AppClassLoader.loadClass(Unknown Source)
	at java.lang.ClassLoader.loadClass(Unknown Source)
	at net.md_5.bungee.connection.InitialHandler.handle(InitialHandler.java:367)
	at net.md_5.bungee.protocol.packet.LoginRequest.handle(LoginRequest.java:36)
	at net.md_5.bungee.netty.HandlerBoss.channelRead(HandlerBoss.java:114)
	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:379)
	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:365)
	at io.netty.channel.AbstractChannelHandlerContext.fireChannelRead(AbstractChannelHandlerContext.java:357)
	at io.netty.handler.timeout.IdleStateHandler.channelRead(IdleStateHandler.java:286)
	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:379)
	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:365)
	at io.netty.channel.AbstractChannelHandlerContext.fireChannelRead(AbstractChannelHandlerContext.java:357)
	at io.netty.handler.codec.MessageToMessageDecoder.channelRead(MessageToMessageDecoder.java:103)
	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:379)
	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:365)
	at io.netty.channel.AbstractChannelHandlerContext.fireChannelRead(AbstractChannelHandlerContext.java:357)
	at io.netty.handler.codec.ByteToMessageDecoder.fireChannelRead(ByteToMessageDecoder.java:324)
	at io.netty.handler.codec.ByteToMessageDecoder.channelRead(ByteToMessageDecoder.java:296)
	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:379)
	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:365)
	at io.netty.channel.AbstractChannelHandlerContext.fireChannelRead(AbstractChannelHandlerContext.java:357)
	at io.netty.handler.codec.ByteToMessageDecoder.handlerRemoved(ByteToMessageDecoder.java:253)
	at io.netty.handler.codec.ByteToMessageDecoder.decodeRemovalReentryProtection(ByteToMessageDecoder.java:514)
	at io.netty.handler.codec.ByteToMessageDecoder.callDecode(ByteToMessageDecoder.java:446)
	at io.netty.handler.codec.ByteToMessageDecoder.channelRead(ByteToMessageDecoder.java:276)
	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:379)
	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:365)
	at io.netty.channel.AbstractChannelHandlerContext.fireChannelRead(AbstractChannelHandlerContext.java:357)
	at io.netty.channel.DefaultChannelPipeline$HeadContext.channelRead(DefaultChannelPipeline.java:1410)
	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:379)
	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:365)
	at io.netty.channel.DefaultChannelPipeline.fireChannelRead(DefaultChannelPipeline.java:919)
	at io.netty.channel.nio.AbstractNioByteChannel$NioByteUnsafe.read(AbstractNioByteChannel.java:166)
	at io.netty.channel.nio.NioEventLoop.processSelectedKey(NioEventLoop.java:722)
	at io.netty.channel.nio.NioEventLoop.processSelectedKeysOptimized(NioEventLoop.java:658)
	at io.netty.channel.nio.NioEventLoop.processSelectedKeys(NioEventLoop.java:584)
	at io.netty.channel.nio.NioEventLoop.run(NioEventLoop.java:496)
	at io.netty.util.concurrent.SingleThreadEventExecutor$4.run(SingleThreadEventExecutor.java:986)
	at io.netty.util.internal.ThreadExecutorMap$2.run(ThreadExecutorMap.java:74)
	at java.lang.Thread.run(Unknown Source)
```