### PR TITLE
fix 1.20.2 can not view skin

### DIFF
--- a/src/main/java/moe/yushi/authlibinjector/transform/support/YggdrasilKeyTransformUnit.java
+++ b/src/main/java/moe/yushi/authlibinjector/transform/support/YggdrasilKeyTransformUnit.java
@@ -47,7 +47,6 @@ import moe.yushi.authlibinjector.util.Logging.Level;
 public class YggdrasilKeyTransformUnit implements TransformUnit {
 
 	public static final List<PublicKey> PUBLIC_KEYS = new CopyOnWriteArrayList<>();
-	private boolean isSignature = false;
 
 	static {
 		PUBLIC_KEYS.add(loadMojangPublicKey());
@@ -140,8 +139,21 @@ public class YggdrasilKeyTransformUnit implements TransformUnit {
 			return Optional.of(new ClassVisitor(ASM9, writer) {
 				@Override
 				public MethodVisitor visitMethod(int access, String name, String desc, String signature, String[] exceptions) {
+					if ("value".equals(name)) {
+						MethodVisitor mv = writer.visitMethod(access, "getValue", desc, signature, exceptions);
+						mv.visitVarInsn(ALOAD, 0);
+						mv.visitFieldInsn(GETFIELD, "com/mojang/authlib/properties/Property", "value", "Ljava/lang/String;");
+						mv.visitInsn(ARETURN);
+						mv.visitMaxs(1, 1);
+						mv.visitEnd();
+					}
 					if ("signature".equals(name)) {
-						isSignature = true;
+						MethodVisitor mv = writer.visitMethod(access, "getSignature", desc, signature, exceptions);
+						mv.visitVarInsn(ALOAD, 0);
+						mv.visitFieldInsn(GETFIELD, "com/mojang/authlib/properties/Property", "signature", "Ljava/lang/String;");
+						mv.visitInsn(ARETURN);
+						mv.visitMaxs(1, 1);
+						mv.visitEnd();
 					}
 					if ("isSignatureValid".equals(name) && "(Ljava/security/PublicKey;)Z".equals(desc)) {
 						ctx.markModified();
@@ -174,9 +186,9 @@ public class YggdrasilKeyTransformUnit implements TransformUnit {
 						MethodVisitor mv = super.visitMethod(access, name, desc, signature, exceptions);
 						mv.visitCode();
 						mv.visitVarInsn(ALOAD, 1);
-						mv.visitMethodInsn(INVOKEVIRTUAL, "com/mojang/authlib/properties/Property", isSignature ? "value" : "getValue", "()Ljava/lang/String;", false);
+						mv.visitMethodInsn(INVOKEVIRTUAL, "com/mojang/authlib/properties/Property", "getValue", "()Ljava/lang/String;", false);
 						mv.visitVarInsn(ALOAD, 1);
-						mv.visitMethodInsn(INVOKEVIRTUAL, "com/mojang/authlib/properties/Property", isSignature ? "signature" : "getSignature", "()Ljava/lang/String;", false);
+						mv.visitMethodInsn(INVOKEVIRTUAL, "com/mojang/authlib/properties/Property", "getSignature", "()Ljava/lang/String;", false);
 						ctx.invokeCallback(mv, YggdrasilKeyTransformUnit.class, "verifyPropertySignature");
 						mv.visitInsn(IRETURN);
 						mv.visitMaxs(-1, -1);

--- a/src/main/java/moe/yushi/authlibinjector/transform/support/YggdrasilKeyTransformUnit.java
+++ b/src/main/java/moe/yushi/authlibinjector/transform/support/YggdrasilKeyTransformUnit.java
@@ -139,15 +139,14 @@ public class YggdrasilKeyTransformUnit implements TransformUnit {
 			return Optional.of(new ClassVisitor(ASM9, writer) {
 				@Override
 				public MethodVisitor visitMethod(int access, String name, String desc, String signature, String[] exceptions) {
-					"value".equals(name) && "()Ljava/lang/String;".equals(desc)
+					if ("value".equals(name) && "()Ljava/lang/String;".equals(desc)) {
 						MethodVisitor mv = writer.visitMethod(access, "getValue", desc, signature, exceptions);
 						mv.visitVarInsn(ALOAD, 0);
 						mv.visitFieldInsn(GETFIELD, "com/mojang/authlib/properties/Property", "value", "Ljava/lang/String;");
 						mv.visitInsn(ARETURN);
 						mv.visitMaxs(-1, -1);
 						mv.visitEnd();
-					}
-					"signature".equals(name) && "()Ljava/lang/String;".equals(desc)
+					} else if ("signature".equals(name) && "()Ljava/lang/String;".equals(desc)) {
 						MethodVisitor mv = writer.visitMethod(access, "getSignature", desc, signature, exceptions);
 						mv.visitVarInsn(ALOAD, 0);
 						mv.visitFieldInsn(GETFIELD, "com/mojang/authlib/properties/Property", "signature", "Ljava/lang/String;");

--- a/src/main/java/moe/yushi/authlibinjector/transform/support/YggdrasilKeyTransformUnit.java
+++ b/src/main/java/moe/yushi/authlibinjector/transform/support/YggdrasilKeyTransformUnit.java
@@ -139,20 +139,20 @@ public class YggdrasilKeyTransformUnit implements TransformUnit {
 			return Optional.of(new ClassVisitor(ASM9, writer) {
 				@Override
 				public MethodVisitor visitMethod(int access, String name, String desc, String signature, String[] exceptions) {
-					if ("value".equals(name)) {
+					"value".equals(name) && "()Ljava/lang/String;".equals(desc)
 						MethodVisitor mv = writer.visitMethod(access, "getValue", desc, signature, exceptions);
 						mv.visitVarInsn(ALOAD, 0);
 						mv.visitFieldInsn(GETFIELD, "com/mojang/authlib/properties/Property", "value", "Ljava/lang/String;");
 						mv.visitInsn(ARETURN);
-						mv.visitMaxs(1, 1);
+						mv.visitMaxs(-1, -1);
 						mv.visitEnd();
 					}
-					if ("signature".equals(name)) {
+					"signature".equals(name) && "()Ljava/lang/String;".equals(desc)
 						MethodVisitor mv = writer.visitMethod(access, "getSignature", desc, signature, exceptions);
 						mv.visitVarInsn(ALOAD, 0);
 						mv.visitFieldInsn(GETFIELD, "com/mojang/authlib/properties/Property", "signature", "Ljava/lang/String;");
 						mv.visitInsn(ARETURN);
-						mv.visitMaxs(1, 1);
+						mv.visitMaxs(-1, -1);
 						mv.visitEnd();
 					}
 					if ("isSignatureValid".equals(name) && "(Ljava/security/PublicKey;)Z".equals(desc)) {


### PR DESCRIPTION
1.20.2 更新了 authlib 版本，并把 Property 改为 record 类。且 net.minecraft.client.resources.SkinManager 中改成了默认获取带有签名的皮肤，导致在 1.20.2 无法加载皮肤。

这个 pr 尝试修复这个问题，我对于 javaagent 不是很了解，这样判断应该有些问题。我自己的测试中皮肤是已经可以加载，服务器中也是。

issues: #225