### PR TITLE
Use empty publicKeySignature in dummy ProfileKeyFilter response

### DIFF
--- a/src/main/java/moe/yushi/authlibinjector/httpd/ProfileKeyFilter.java
+++ b/src/main/java/moe/yushi/authlibinjector/httpd/ProfileKeyFilter.java
@@ -74,8 +74,8 @@ public class ProfileKeyFilter implements URLFilter {
 		keyPairObj.put("privateKey", privateKeyPEM);
 		keyPairObj.put("publicKey", publicKeyPEM);
 		response.put("keyPair", keyPairObj);
-		response.put("publicKeySignature", "AA==");
-		response.put("publicKeySignatureV2", "AA==");
+		response.put("publicKeySignature", "");
+		response.put("publicKeySignatureV2", "");
 		response.put("expiresAt", DateTimeFormatter.ISO_INSTANT.format(expiresAt));
 		response.put("refreshedAfter", DateTimeFormatter.ISO_INSTANT.format(refreshedAfter));
 		return response;


### PR DESCRIPTION
If we send an invalid signature here (`AA==`), then the vanilla server will throw an error while handling the LoginHelloC2S packet, even if `enforce-secure-profile` is `false` in `server.properties`. The client will be disconnected with the message "Invalid signature for profile public key. Try restarting your game."

It's better to send an empty string; the server will simply ignore the missing publicKeySignature if `enforce-secure-profile` is false.

Resolves https://github.com/unmojang/drasl/issues/109.