### PR TITLE
Added the ability to configure endpoints and their fallbacks in metadata

### DIFF
--- a/src/main/java/moe/yushi/authlibinjector/UrlsMetadata.java
+++ b/src/main/java/moe/yushi/authlibinjector/UrlsMetadata.java
@@ -1,0 +1,40 @@
+package moe.yushi.authlibinjector;
+
+import java.util.Optional;
+
+public class UrlsMetadata {
+
+    public UrlsMetadata(Optional<String> apiURL, Optional<String> authserverUrl, Optional<String> sessionserverUrl, Optional<String> skinsUrl, Optional<String> minecraftservicesUrl) {
+        this.apiURL = apiURL;
+        this.authserverUrl = authserverUrl;
+        this.sessionserverUrl = sessionserverUrl;
+        this.skinsUrl = skinsUrl;
+        this.minecraftservicesUrl = minecraftservicesUrl;
+    }
+
+    private final Optional<String> apiURL;
+    private final Optional<String> authserverUrl;
+    private final Optional<String> sessionserverUrl;
+    private final Optional<String> skinsUrl;
+    private final Optional<String> minecraftservicesUrl;
+
+    public Optional<String> getApiURL() {
+        return apiURL;
+    }
+
+    public Optional<String> getAuthserverUrl() {
+        return authserverUrl;
+    }
+
+    public Optional<String> getSessionserverUrl() {
+        return sessionserverUrl;
+    }
+
+    public Optional<String> getSkinsUrl() {
+        return skinsUrl;
+    }
+
+    public Optional<String> getMinecraftservicesUrl() {
+        return minecraftservicesUrl;
+    }
+}

--- a/src/main/java/moe/yushi/authlibinjector/httpd/URLProcessor.java
+++ b/src/main/java/moe/yushi/authlibinjector/httpd/URLProcessor.java
@@ -22,21 +22,19 @@ import static moe.yushi.authlibinjector.util.Logging.log;
 import static moe.yushi.authlibinjector.util.Logging.Level.DEBUG;
 import static moe.yushi.authlibinjector.util.Logging.Level.INFO;
 import static moe.yushi.authlibinjector.util.Logging.Level.WARNING;
+
+import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
 import java.net.HttpURLConnection;
 import java.net.URL;
-import java.util.Arrays;
-import java.util.HashSet;
-import java.util.LinkedHashMap;
-import java.util.List;
-import java.util.Map;
+import java.nio.charset.StandardCharsets;
+import java.util.*;
 import java.util.Map.Entry;
-import java.util.Optional;
-import java.util.Set;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
+
 import moe.yushi.authlibinjector.Config;
 import moe.yushi.authlibinjector.internal.fi.iki.elonen.IHTTPSession;
 import moe.yushi.authlibinjector.internal.fi.iki.elonen.IStatus;
@@ -46,203 +44,219 @@ import moe.yushi.authlibinjector.internal.fi.iki.elonen.Status;
 
 public class URLProcessor {
 
-	private static final Pattern URL_REGEX = Pattern.compile("^(?<protocol>https?):\\/\\/(?<domain>[^\\/]+)(?<path>\\/?.*)$");
-	private static final Pattern LOCAL_URL_REGEX = Pattern.compile("^/(?<protocol>https?)/(?<domain>[^\\/]+)(?<path>\\/.*)$");
+    private static final Pattern URL_REGEX = Pattern.compile("^(?<protocol>https?):\\/\\/(?<domain>[^\\/]+)(?<path>\\/?.*)$");
+    private static final Pattern LOCAL_URL_REGEX = Pattern.compile("^/(?<protocol>https?)/(?<domain>[^\\/]+)(?<path>\\/.*)$");
 
-	private List<URLFilter> filters;
-	private URLRedirector redirector;
+    private List<URLFilter> filters;
+    private URLRedirector redirector;
 
-	public URLProcessor(List<URLFilter> filters, URLRedirector redirector) {
-		this.filters = filters;
-		this.redirector = redirector;
-	}
+    public URLProcessor(List<URLFilter> filters, URLRedirector redirector) {
+        this.filters = filters;
+        this.redirector = redirector;
+    }
 
-	/**
-	 * Transforms the input URL(which is grabbed from the bytecode).
-	 *
-	 * If any filter is interested in the URL, the URL will be redirected to the local HTTP server.
-	 * Otherwise, the URLRedirector will be invoked to determine whether the URL should be modified
-	 * and pointed to the customized authentication server.
-	 * If none of above happens, empty is returned.
-	 *
-	 * @return the transformed URL, or empty if it doesn't need to be transformed
-	 */
-	public Optional<String> transformURL(String inputUrl) {
-		if (!inputUrl.startsWith("http")) {
-			// fast path
-			return Optional.empty();
-		}
-		Matcher matcher = URL_REGEX.matcher(inputUrl);
-		if (!matcher.find()) {
-			return Optional.empty();
-		}
-		String protocol = matcher.group("protocol");
-		String domain = matcher.group("domain");
-		String path = matcher.group("path");
+    /**
+     * Transforms the input URL(which is grabbed from the bytecode).
+     * <p>
+     * If any filter is interested in the URL, the URL will be redirected to the local HTTP server.
+     * Otherwise, the URLRedirector will be invoked to determine whether the URL should be modified
+     * and pointed to the customized authentication server.
+     * If none of above happens, empty is returned.
+     *
+     * @return the transformed URL, or empty if it doesn't need to be transformed
+     */
+    public Optional<String> transformURL(String inputUrl) {
+        if (!inputUrl.startsWith("http")) {
+            // fast path
+            return Optional.empty();
+        }
+        Matcher matcher = URL_REGEX.matcher(inputUrl);
+        if (!matcher.find()) {
+            return Optional.empty();
+        }
+        String protocol = matcher.group("protocol");
+        String domain = matcher.group("domain");
+        String path = matcher.group("path");
 
-		Optional<String> result = transform(protocol, domain, path);
-		if (result.isPresent()) {
-			log(DEBUG, "Transformed url [" + inputUrl + "] to [" + result.get() + "]");
-		}
-		return result;
-	}
+        Optional<String> result = transform(protocol, domain, path);
+        if (result.isPresent()) {
+            log(DEBUG, "Transformed url [" + inputUrl + "] to [" + result.get() + "]");
+        }
+        return result;
+    }
 
-	private Optional<String> transform(String protocol, String domain, String path) {
-		boolean handleLocally = false;
-		for (URLFilter filter : filters) {
-			if (filter.canHandle(domain)) {
-				handleLocally = true;
-				break;
-			}
-		}
+    private Optional<String> transform(String protocol, String domain, String path) {
+        boolean handleLocally = false;
+        for (URLFilter filter : filters) {
+            if (filter.canHandle(domain)) {
+                handleLocally = true;
+                break;
+            }
+        }
 
-		if (handleLocally) {
-			return Optional.of("http://127.0.0.1:" + getLocalApiPort() + "/" + protocol + "/" + domain + path);
-		}
+        if (handleLocally) {
+            return Optional.of("http://127.0.0.1:" + getLocalApiPort() + "/" + protocol + "/" + domain + path);
+        }
 
-		return redirector.redirect(domain, path);
-	}
+        return redirector.redirect(domain, path);
+    }
 
-	private DebugApiEndpoint debugApi = new DebugApiEndpoint();
-	private volatile NanoHTTPD httpd;
-	private final Object httpdLock = new Object();
+    private DebugApiEndpoint debugApi = new DebugApiEndpoint();
+    private volatile NanoHTTPD httpd;
+    private final Object httpdLock = new Object();
 
-	private int getLocalApiPort() {
-		synchronized (httpdLock) {
-			if (httpd == null) {
-				httpd = createHttpd();
-				try {
-					httpd.start();
-				} catch (IOException e) {
-					throw new IllegalStateException("Httpd failed to start");
-				}
-				log(INFO, "Httpd is running on port " + httpd.getListeningPort());
-			}
-			return httpd.getListeningPort();
-		}
-	}
+    private int getLocalApiPort() {
+        synchronized (httpdLock) {
+            if (httpd == null) {
+                httpd = createHttpd();
+                try {
+                    httpd.start();
+                } catch (IOException e) {
+                    throw new IllegalStateException("Httpd failed to start");
+                }
+                log(INFO, "Httpd is running on port " + httpd.getListeningPort());
+            }
+            return httpd.getListeningPort();
+        }
+    }
 
-	private NanoHTTPD createHttpd() {
-		return new NanoHTTPD("127.0.0.1", Config.httpdPort) {
-			@Override
-			public Response serve(IHTTPSession session) {
-				if (session.getUri().startsWith("/debug/")) {
-					return debugApi.serve(session);
-				}
+    private NanoHTTPD createHttpd() {
+        return new NanoHTTPD("127.0.0.1", Config.httpdPort) {
+            @Override
+            public Response serve(IHTTPSession session) {
+                return serve(session, false);
+            }
 
-				Matcher matcher = LOCAL_URL_REGEX.matcher(session.getUri());
-				if (matcher.find()) {
-					String protocol = matcher.group("protocol");
-					String domain = matcher.group("domain");
-					String path = matcher.group("path");
-					for (URLFilter filter : filters) {
-						if (filter.canHandle(domain)) {
-							Optional<Response> result;
-							try {
-								result = filter.handle(domain, path, session);
-							} catch (Throwable e) {
-								log(WARNING, "An error occurred while processing request [" + session.getUri() + "]", e);
-								return Response.newFixedLength(Status.INTERNAL_ERROR, CONTENT_TYPE_TEXT, "Internal Server Error");
-							}
+            private Response serve(IHTTPSession session, boolean isFallback) {
+                if (session.getUri().startsWith("/debug/")) {
+                    return debugApi.serve(session);
+                }
 
-							if (result.isPresent()) {
-								log(DEBUG, "Request to [" + session.getUri() + "] is handled by [" + filter + "]");
-								return result.get();
-							}
-						}
-					}
+                Matcher matcher = LOCAL_URL_REGEX.matcher(session.getUri());
+                if (matcher.find()) {
+                    String protocol = matcher.group("protocol");
+                    String domain = matcher.group("domain");
+                    String path = matcher.group("path");
+                    for (URLFilter filter : filters) {
+                        if (filter.canHandle(domain)) {
+                            Optional<Response> result;
+                            try {
+                                result = filter.handle(domain, path, session);
+                            } catch (Throwable e) {
+                                log(WARNING, "An error occurred while processing request [" + session.getUri() + "]", e);
+                                return Response.newFixedLength(Status.INTERNAL_ERROR, CONTENT_TYPE_TEXT, "Internal Server Error");
+                            }
 
-					String target = redirector.redirect(domain, path)
-							.orElseGet(() -> protocol + "://" + domain + path);
-					try {
-						return reverseProxy(session, target);
-					} catch (IOException e) {
-						log(WARNING, "Reverse proxy error", e);
-						return Response.newFixedLength(Status.BAD_GATEWAY, CONTENT_TYPE_TEXT, "Bad Gateway");
-					}
-				} else {
-					log(DEBUG, "No handler is found for [" + session.getUri() + "]");
-					return Response.newFixedLength(Status.NOT_FOUND, CONTENT_TYPE_TEXT, "Not Found");
-				}
-			}
-		};
-	}
+                            if (result.isPresent()) {
+                                log(DEBUG, "Request to [" + session.getUri() + "] is handled by [" + filter + "]");
+                                return result.get();
+                            }
+                        }
+                    }
 
-	private static final Set<String> ignoredHeaders = new HashSet<>(Arrays.asList("host", "expect", "connection", "keep-alive", "transfer-encoding"));
+                    String target = redirector.redirect(domain, path)
+                            .orElseGet(() -> protocol + "://" + domain + path);
 
-	@SuppressWarnings("resource")
-	private Response reverseProxy(IHTTPSession session, String upstream) throws IOException {
-		String method = session.getMethod();
+                    try {
+                        return reverseProxy(session, target);
+                    } catch (IOException e) {
+                        if (!isFallback) {
+                            log(WARNING, "Request to " + target + " error, try fallback", e);
 
-		String url = session.getQueryParameterString() == null ? upstream : upstream + "?" + session.getQueryParameterString();
+                            if (!redirector.UseFallback(domain)) {
+                                log(WARNING, "No available fallbacks for " + domain);
+                                return Response.newFixedLength(Status.BAD_GATEWAY, CONTENT_TYPE_TEXT, "Bad Gateway");
+                            }
 
-		Map<String, String> requestHeaders = new LinkedHashMap<>(session.getHeaders());
-		ignoredHeaders.forEach(requestHeaders::remove);
+                            return serve(session, true);
+                        }
 
-		InputStream clientIn = session.getInputStream();
+                        log(WARNING, "Reverse proxy error", e);
+                        return Response.newFixedLength(Status.BAD_GATEWAY, CONTENT_TYPE_TEXT, "Bad Gateway");
+                    }
+                } else {
+                    log(DEBUG, "No handler is found for [" + session.getUri() + "]");
+                    return Response.newFixedLength(Status.NOT_FOUND, CONTENT_TYPE_TEXT, "Not Found");
+                }
+            }
+        };
+    }
 
-		log(DEBUG, "Reverse proxy: > " + method + " " + url + ", headers: " + requestHeaders);
+    private static final Set<String> ignoredHeaders = new HashSet<>(Arrays.asList("host", "expect", "connection", "keep-alive", "transfer-encoding"));
 
-		HttpURLConnection conn = (HttpURLConnection) new URL(url).openConnection();
-		conn.setRequestMethod(method);
-		conn.setDoOutput(clientIn != null);
-		requestHeaders.forEach(conn::setRequestProperty);
+    @SuppressWarnings("resource")
+    private Response reverseProxy(IHTTPSession session, String upstream) throws IOException {
+        String method = session.getMethod();
 
-		if (clientIn != null && !method.equalsIgnoreCase("GET") && !method.equalsIgnoreCase("HEAD")) {
-			try (OutputStream upstreamOut = conn.getOutputStream()) {
-				transfer(clientIn, upstreamOut);
-			}
-		}
+        String url = session.getQueryParameterString() == null ? upstream : upstream + "?" + session.getQueryParameterString();
 
-		int responseCode = conn.getResponseCode();
-		String reponseMessage = conn.getResponseMessage();
-		Map<String, List<String>> responseHeaders = new LinkedHashMap<>();
-		conn.getHeaderFields().forEach((name, values) -> {
-			if (name != null && !ignoredHeaders.contains(name.toLowerCase())) {
-				responseHeaders.put(name, values);
-			}
-		});
-		InputStream upstreamIn;
-		try {
-			upstreamIn = conn.getInputStream();
-		} catch (IOException e) {
-			upstreamIn = conn.getErrorStream();
-		}
-		log(DEBUG, "Reverse proxy: < " + responseCode + " " + reponseMessage + " , headers: " + responseHeaders);
+        Map<String, String> requestHeaders = new LinkedHashMap<>(session.getHeaders());
+        ignoredHeaders.forEach(requestHeaders::remove);
 
-		IStatus status = new IStatus() {
-			@Override
-			public int getRequestStatus() {
-				return responseCode;
-			}
+        InputStream clientIn = session.getInputStream();
 
-			@Override
-			public String getDescription() {
-				return responseCode + " " + reponseMessage;
-			}
-		};
+        log(DEBUG, "Reverse proxy: > " + method + " " + url + ", headers: " + requestHeaders);
 
-		long contentLength = -1;
-		for (Entry<String, List<String>> header : responseHeaders.entrySet()) {
-			if ("content-length".equalsIgnoreCase(header.getKey())) {
-				contentLength = Long.parseLong(header.getValue().get(0));
-				break;
-			}
-		}
+        HttpURLConnection conn = (HttpURLConnection) new URL(url).openConnection();
+        conn.setRequestMethod(method);
+        conn.setDoOutput(clientIn != null);
+        requestHeaders.forEach(conn::setRequestProperty);
 
-		Response response;
-		if (contentLength == -1) {
-			if (conn.getHeaderField("transfer-encoding") == null) {
-				// no content
-				response = Response.newFixedLength(status, null, upstreamIn, 0);
-			} else {
-				response = Response.newChunked(status, null, upstreamIn);
-			}
-		} else {
-			response = Response.newFixedLength(status, null, upstreamIn, contentLength);
-		}
-		responseHeaders.forEach((name, values) -> values.forEach(value -> response.addHeader(name, value)));
+        if (clientIn != null && !method.equalsIgnoreCase("GET") && !method.equalsIgnoreCase("HEAD")) {
+            try (OutputStream upstreamOut = conn.getOutputStream()) {
+                transfer(clientIn, upstreamOut);
+            }
+        }
 
-		return response;
-	}
+        int responseCode = conn.getResponseCode();
+        String reponseMessage = conn.getResponseMessage();
+        Map<String, List<String>> responseHeaders = new LinkedHashMap<>();
+        conn.getHeaderFields().forEach((name, values) -> {
+            if (name != null && !ignoredHeaders.contains(name.toLowerCase())) {
+                responseHeaders.put(name, values);
+            }
+        });
+        InputStream upstreamIn;
+        try {
+            upstreamIn = conn.getInputStream();
+        } catch (IOException e) {
+            upstreamIn = conn.getErrorStream();
+        }
+        log(DEBUG, "Reverse proxy: < " + responseCode + " " + reponseMessage + " , headers: " + responseHeaders);
+
+        IStatus status = new IStatus() {
+            @Override
+            public int getRequestStatus() {
+                return responseCode;
+            }
+
+            @Override
+            public String getDescription() {
+                return responseCode + " " + reponseMessage;
+            }
+        };
+
+        long contentLength = -1;
+        for (Entry<String, List<String>> header : responseHeaders.entrySet()) {
+            if ("content-length".equalsIgnoreCase(header.getKey())) {
+                contentLength = Long.parseLong(header.getValue().get(0));
+                break;
+            }
+        }
+
+        Response response;
+        if (contentLength == -1) {
+            if (conn.getHeaderField("transfer-encoding") == null) {
+                // no content
+                response = Response.newFixedLength(status, null, upstreamIn, 0);
+            } else {
+                response = Response.newChunked(status, null, upstreamIn);
+            }
+        } else {
+            response = Response.newFixedLength(status, null, upstreamIn, contentLength);
+        }
+        responseHeaders.forEach((name, values) -> values.forEach(value -> response.addHeader(name, value)));
+
+        return response;
+    }
 }

--- a/src/main/java/moe/yushi/authlibinjector/httpd/URLRedirector.java
+++ b/src/main/java/moe/yushi/authlibinjector/httpd/URLRedirector.java
@@ -24,4 +24,5 @@ import java.util.Optional;
  */
 public interface URLRedirector {
 	Optional<String> redirect(String domain, String path);
+	boolean UseFallback(String domain);
 }

--- a/src/test/java/moe/yushi/authlibinjector/test/DefaultURLRedirectorTest.java
+++ b/src/test/java/moe/yushi/authlibinjector/test/DefaultURLRedirectorTest.java
@@ -27,7 +27,7 @@ import moe.yushi.authlibinjector.httpd.DefaultURLRedirector;
 public class DefaultURLRedirectorTest {
 
 	private String apiRoot = "https://yggdrasil.example.com/";
-	private DefaultURLRedirector redirector = new DefaultURLRedirector(new APIMetadata(apiRoot, emptyList(), emptyMap(), Optional.empty()));
+	private DefaultURLRedirector redirector = new DefaultURLRedirector(new APIMetadata(apiRoot, emptyList(), emptyMap(), Optional.empty(), Optional.empty(), Optional.empty()));
 
 	private void testTransform(String domain, String path, String output) {
 		assertEquals(redirector.redirect(domain, path).get(), output);


### PR DESCRIPTION
Added two parameters in metadata - urlsRedefining and fallbackUrlsRedefining.

#### Each of them contains the following string fields:
- api - root URL for the analog of api.mojang.com
- authserver - root URL for the analog of authserver.mojang.com
- sessionserver - root URL for the analog of sessionserver.mojang.com
- skins - root URL for the analog of skins.minecraft.net
- minecraftservices - root URL for the analog of api.minecraftservices.com

#### Behavior:
- If a request to a URL from urlsRedefining fails, the corresponding URL from fallbackUrlsRedefining will be used instead.
- If any field is missing, the default logic will be applied

#### Example:
<img width="624" height="292" alt="image" src="https://github.com/user-attachments/assets/f3d737cc-d2b5-4751-93cd-ccf434ef6192" />
