### PR TITLE
fix(http): 修复在连接未完全断开的情况下继续尝试发送响应

### DIFF
--- a/src/main/java/moe/yushi/authlibinjector/internal/fi/iki/elonen/HTTPSession.java
+++ b/src/main/java/moe/yushi/authlibinjector/internal/fi/iki/elonen/HTTPSession.java
@@ -95,6 +95,8 @@ class HTTPSession implements IHTTPSession {
 	private boolean isServing;
 	private final Object servingLock = new Object();
 
+    public boolean Disconnected;
+
 	public HTTPSession(InputStream inputStream, OutputStream outputStream, InetSocketAddress remoteAddr) {
 		this.inputStream = new BufferedInputStream(inputStream, BUFSIZE);
 		this.outputStream = outputStream;
@@ -268,14 +270,13 @@ class HTTPSession implements IHTTPSession {
 			if (!keepAlive || "close".equals(r.getHeader("connection"))) {
 				throw new ConnectionCloseException();
 			}
-		} catch (SocketException e) {
+		} catch (SocketException | SocketTimeoutException e) {
+            // treat socket timeouts the same way we treat socket exceptions
+            // i.e. close the stream & finalAccept object by throwing the
+            // exception up the call stack.
+
 			// throw it out to close socket object (finalAccept)
 			throw e;
-		} catch (SocketTimeoutException ste) {
-			// treat socket timeouts the same way we treat socket exceptions
-			// i.e. close the stream & finalAccept object by throwing the
-			// exception up the call stack.
-			throw ste;
 		} catch (IOException ioe) {
 			Response resp = Response.newFixedLength(Status.INTERNAL_ERROR, CONTENT_TYPE_TEXT, "SERVER INTERNAL ERROR: IOException: " + ioe.getMessage());
 			resp.send(this.outputStream);
@@ -285,6 +286,7 @@ class HTTPSession implements IHTTPSession {
 			resp.send(this.outputStream);
 			NanoHTTPD.safeClose(this.outputStream);
 		} finally {
+            Disconnected = true;
 			NanoHTTPD.safeClose(r);
 		}
 	}

--- a/src/main/java/moe/yushi/authlibinjector/internal/fi/iki/elonen/NanoHTTPD.java
+++ b/src/main/java/moe/yushi/authlibinjector/internal/fi/iki/elonen/NanoHTTPD.java
@@ -101,6 +101,7 @@ public abstract class NanoHTTPD {
 				outputStream = this.acceptSocket.getOutputStream();
 				HTTPSession session = new HTTPSession(this.inputStream, outputStream, (InetSocketAddress) this.acceptSocket.getRemoteSocketAddress());
 				while (!this.acceptSocket.isClosed()) {
+                    if(session.Disconnected) break;
 					session.execute(NanoHTTPD.this::serve);
 				}
 			} catch (ConnectionCloseException e) {


### PR DESCRIPTION
为 HTTPSession 添加了 Disconnected 属性

为 NanoHTTPD.java Ln 103 的循环分支添加 Disconnected 属性的判断，以解决 PCL CE 在主动扫描端口时出现循环写入日志的 Bug

整理了 HTTPSession 的 catch 分支，将 SocketException 和 SocketTimeoutException 合并为一个分支抛出

简单将注释合并了，欢迎提意见