### PR TITLE
ci: upgrade actions/upload-artifact from v3 to v4

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,6 +27,6 @@ jobs:
       run: ./gradlew test
 
     - name: Upload artifacts
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: build/libs/*


### PR DESCRIPTION
将 ci 文件的 actions/upload-artifact 更新到 v4，以解决测试一启动就跑炸的问题

ref https://github.blog/changelog/2024-04-16-deprecation-notice-v3-of-the-artifact-actions/