### PR TITLE
Support Floodgate Global Linking

### DIFF
--- a/src/main/java/moe/yushi/authlibinjector/AuthlibInjector.java
+++ b/src/main/java/moe/yushi/authlibinjector/AuthlibInjector.java
@@ -44,6 +44,7 @@ import java.util.Set;
 import java.util.stream.Stream;
 import moe.yushi.authlibinjector.httpd.AntiFeaturesFilter;
 import moe.yushi.authlibinjector.httpd.DefaultURLRedirector;
+import moe.yushi.authlibinjector.httpd.FloodgateGlobalLinkingFilter;
 import moe.yushi.authlibinjector.httpd.LegacySkinAPIFilter;
 import moe.yushi.authlibinjector.httpd.ProfileKeyFilter;
 import moe.yushi.authlibinjector.httpd.PublickeysFilter;
@@ -257,6 +258,11 @@ public final class AuthlibInjector {
 		boolean profileKeyDefault = Boolean.TRUE.equals(config.getMeta().get("feature.enable_profile_key"));
 		if (!Config.profileKey.isEnabled(profileKeyDefault)) {
 			filters.add(new ProfileKeyFilter());
+		}
+
+		boolean floodgateGlobalLinkingDefault = Boolean.TRUE.equals(config.getMeta().get("feature.floodgate_global_linking"));
+		if (floodgateGlobalLinkingDefault) {
+			filters.add(new FloodgateGlobalLinkingFilter(config.getApiRoot()));
 		}
 
 		filters.add(new PublickeysFilter());

--- a/src/main/java/moe/yushi/authlibinjector/httpd/FloodgateGlobalLinkingFilter.java
+++ b/src/main/java/moe/yushi/authlibinjector/httpd/FloodgateGlobalLinkingFilter.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright (C) 2026  Haowei Wen <yushijinhun@gmail.com> and contributors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package moe.yushi.authlibinjector.httpd;
+
+import static moe.yushi.authlibinjector.util.IOUtils.CONTENT_TYPE_TEXT;
+import static moe.yushi.authlibinjector.util.Logging.log;
+import static moe.yushi.authlibinjector.util.Logging.Level.WARNING;
+
+import java.io.IOException;
+import java.util.Optional;
+import java.util.regex.Pattern;
+
+import moe.yushi.authlibinjector.internal.fi.iki.elonen.IHTTPSession;
+import moe.yushi.authlibinjector.internal.fi.iki.elonen.Response;
+import moe.yushi.authlibinjector.internal.fi.iki.elonen.Status;
+
+/**
+ * Proxies Floodgate Global Linking query requests to the custom authentication server.
+ */
+public class FloodgateGlobalLinkingFilter implements URLFilter {
+
+	private static final String GEYSER_GLOBAL_API_DOMAIN = "api.geysermc.org";
+	private static final Pattern LINK_QUERY_PATH = Pattern.compile("^/v2/link/(bedrock|java)/[^/]+$");
+
+	private String apiRoot;
+
+	public FloodgateGlobalLinkingFilter(String apiRoot) {
+		this.apiRoot = apiRoot.endsWith("/") ? apiRoot : apiRoot + "/";
+	}
+
+	@Override
+	public boolean canHandle(String domain) {
+		return domain.equals(GEYSER_GLOBAL_API_DOMAIN);
+	}
+
+	@Override
+	public Optional<Response> handle(String domain, String path, IHTTPSession session) throws IOException {
+		if (!domain.equals(GEYSER_GLOBAL_API_DOMAIN) || !session.getMethod().equals("GET") || !LINK_QUERY_PATH.matcher(path).find()) {
+			return Optional.empty();
+		}
+
+		String target = apiRoot + "geyser" + path;
+
+		try {
+			return Optional.of(URLProcessor.reverseProxy(session, target));
+		} catch (IOException e) {
+			log(WARNING, "Failed to proxy Floodgate Global Linking request to [" + target + "]", e);
+			return Optional.of(Response.newFixedLength(Status.BAD_GATEWAY, CONTENT_TYPE_TEXT, "Bad Gateway"));
+		}
+	}
+}

--- a/src/main/java/moe/yushi/authlibinjector/httpd/URLProcessor.java
+++ b/src/main/java/moe/yushi/authlibinjector/httpd/URLProcessor.java
@@ -171,7 +171,7 @@ public class URLProcessor {
 	private static final Set<String> ignoredHeaders = new HashSet<>(Arrays.asList("host", "expect", "connection", "keep-alive", "transfer-encoding"));
 
 	@SuppressWarnings("resource")
-	private Response reverseProxy(IHTTPSession session, String upstream) throws IOException {
+	static Response reverseProxy(IHTTPSession session, String upstream) throws IOException {
 		String method = session.getMethod();
 
 		String url = session.getQueryParameterString() == null ? upstream : upstream + "?" + session.getQueryParameterString();


### PR DESCRIPTION
This Pull Request resolves #291.

Code generated by OpenAI Codex with GPT-5.5 xhigh.

To enable Floodgate Global Linking support, the auth server must add `feature.floodgate_global_linking` feature flag to their metadata and implement APIs described below.

## APIs to implement

### Endpoints

```http
GET /geyser/v2/link/bedrock/{xuid}
GET /geyser/v2/link/java/{uuid}
```

`xuid` is a 64-bit integer, and `uuid` can be a UUID with or without dashes.

### Success Responses

The two APIs have the same JSON response:

```json
{
  "bedrock_id": 12345678901234567890, # XUID
  "java_id": "f702c5d3-9d5c-457f-80c6-91c664757092", # Java Edition UUID with dashes
  "java_name": "SSSSSteven", # Java Edition profile name
  "last_name_update": 1780453291994 # Unix timestamp of last profile name change
}
```

### Error Responses

If no link exists for the specified UUID or XUID, these two APIs should respond `HTTP 200 OK` with an empty JSON object:

```json
{}
```

If the provided `xuid` or `uuid` is malformed, these two APIs should respond `HTTP 400 Bad Request` with the following JSON body:

```json
{
  "message": "human readable error message"
}
```

## References

Geyser REST APIs doc:

- [Get linked Java account from Bedrock xuid](https://geysermc.org/wiki/api/api.geysermc.org/global-api-web-api-link-controller-get-bedrock-link-v-2)
- [Get linked Bedrock account from Java UUID](https://geysermc.org/wiki/api/api.geysermc.org/global-api-web-api-link-controller-get-java-link-v-2)
- [Full OpenAPI doc (JSON)](https://github.com/GeyserMC/GeyserWebsite/blob/0b62a113bbe8a31aa84a2ad664880024abbc75c6/openapi/global.json)