### PR TITLE
ci: upgrade actions version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,10 +11,10 @@ jobs:
 
     steps:
     - name: Checkout
-      uses: actions/checkout@v3
+      uses: actions/checkout@v7
 
     - name: Setup JDK
-      uses: actions/setup-java@v3
+      uses: actions/setup-java@v5
       with:
         distribution: temurin
         java-version: 17

--- a/.github/workflows/create_release.yml
+++ b/.github/workflows/create_release.yml
@@ -66,7 +66,7 @@ jobs:
             Build number: ${{ steps.parse_pr.outputs.build_number }}  
 
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v7
         with:
           ref: ${{ steps.parse_pr.outputs.commit }}
 

--- a/.github/workflows/deploy_wiki.yml
+++ b/.github/workflows/deploy_wiki.yml
@@ -13,7 +13,7 @@ jobs:
       pages: write  # To push to a GitHub Pages site
       id-token: write # To update the deployment status
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
         with:
           fetch-depth: 0
       - uses: cachix/install-nix-action@v20
@@ -27,7 +27,7 @@ jobs:
       - name: Setup Pages
         uses: actions/configure-pages@v4
       - name: Upload artifact
-        uses: actions/upload-pages-artifact@v3
+        uses: actions/upload-pages-artifact@v5
         with:
           # Upload entire repository
           path: 'wiki/book'


### PR DESCRIPTION
Upgraded some reusable workflow versions so all workflows use the supported node.js v24 version.