### PR TITLE
Support 26.3-snapshot-2+

### DIFF
--- a/src/main/java/moe/yushi/authlibinjector/AuthlibInjector.java
+++ b/src/main/java/moe/yushi/authlibinjector/AuthlibInjector.java
@@ -44,6 +44,7 @@ import java.util.Set;
 import java.util.stream.Stream;
 import moe.yushi.authlibinjector.httpd.AntiFeaturesFilter;
 import moe.yushi.authlibinjector.httpd.DefaultURLRedirector;
+import moe.yushi.authlibinjector.httpd.DiscoveryFilter;
 import moe.yushi.authlibinjector.httpd.LegacySkinAPIFilter;
 import moe.yushi.authlibinjector.httpd.ProfileKeyFilter;
 import moe.yushi.authlibinjector.httpd.PublickeysFilter;
@@ -260,6 +261,8 @@ public final class AuthlibInjector {
 		}
 
 		filters.add(new PublickeysFilter());
+
+		filters.add(new DiscoveryFilter());
 
 		return filters;
 	}

--- a/src/main/java/moe/yushi/authlibinjector/httpd/AntiFeaturesFilter.java
+++ b/src/main/java/moe/yushi/authlibinjector/httpd/AntiFeaturesFilter.java
@@ -39,7 +39,7 @@ public class AntiFeaturesFilter implements URLFilter {
 	}
 
 	@Override
-	public Optional<Response> handle(String domain, String path, IHTTPSession session) throws IOException {
+	public Optional<Response> handle(URLProcessor urlProcessor, String domain, String path, IHTTPSession session) throws IOException {
 		if (domain.equals("api.minecraftservices.com") && path.equals("/privileges") && session.getMethod().equals("GET")) {
 			return Optional.of(Response.newFixedLength(Status.OK, CONTENT_TYPE_JSON, RESPONSE_PRIVILEGES));
 		} else if (domain.equals("api.minecraftservices.com") && path.equals("/player/attributes") && session.getMethod().equals("GET")) {

--- a/src/main/java/moe/yushi/authlibinjector/httpd/DiscoveryFilter.java
+++ b/src/main/java/moe/yushi/authlibinjector/httpd/DiscoveryFilter.java
@@ -1,0 +1,91 @@
+/*
+ * Copyright (C) 2026  Haowei Wen <yushijinhun@gmail.com> and contributors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package moe.yushi.authlibinjector.httpd;
+
+import static moe.yushi.authlibinjector.util.IOUtils.CONTENT_TYPE_JSON;
+import static moe.yushi.authlibinjector.util.IOUtils.asBytes;
+import static moe.yushi.authlibinjector.util.IOUtils.asString;
+import static moe.yushi.authlibinjector.util.JsonUtils.asJsonObject;
+import static moe.yushi.authlibinjector.util.JsonUtils.parseJson;
+import static moe.yushi.authlibinjector.util.Logging.Level.DEBUG;
+import static moe.yushi.authlibinjector.util.Logging.log;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.UncheckedIOException;
+import java.util.Optional;
+import java.util.concurrent.ConcurrentHashMap;
+import moe.yushi.authlibinjector.internal.fi.iki.elonen.IHTTPSession;
+import moe.yushi.authlibinjector.internal.fi.iki.elonen.Response;
+import moe.yushi.authlibinjector.internal.fi.iki.elonen.Status;
+import moe.yushi.authlibinjector.internal.org.json.simple.JSONArray;
+import moe.yushi.authlibinjector.internal.org.json.simple.JSONObject;
+
+public class DiscoveryFilter implements URLFilter {
+
+	public static final JSONObject MOJANG_DISCOVERY_JSON;
+
+	private final ConcurrentHashMap<URLProcessor, JSONObject> transformedDiscoveryJSONs = new ConcurrentHashMap<>();
+
+	static {
+		// Hardcode current response from discovery endpoint in case Mojang
+		// moves an endpoint to somewhere the authlib-injector filters don't
+		// recognize
+		try (InputStream in = DiscoveryFilter.class.getResourceAsStream("/discovery_minecraftservices_com_minecraft_client.json")) {
+			MOJANG_DISCOVERY_JSON = asJsonObject(parseJson(asString(asBytes(in))));
+		} catch (IOException | UncheckedIOException e) {
+			throw new RuntimeException("Failed to load hardcoded Mojang discovery response", e);
+		}
+	}
+
+	@Override
+	public boolean canHandle(String domain) {
+		return domain.equals("discovery.minecraftservices.com");
+	}
+
+	@Override
+	public Optional<Response> handle(URLProcessor urlProcessor, String domain, String path, IHTTPSession session) throws IOException {
+		if (domain.equals("discovery.minecraftservices.com") && path.equals("/minecraft/client") && session.getMethod().equals("GET")) {
+		JSONObject response = transformedDiscoveryJSONs.computeIfAbsent(urlProcessor, p -> {
+			JSONObject transformed = (JSONObject) transformDiscoveryJSON(MOJANG_DISCOVERY_JSON, p);
+			log(DEBUG, "Transformed discovery JSON: " + transformed.toJSONString());
+			return transformed;
+		});
+		return Optional.of(Response.newFixedLength(Status.OK, CONTENT_TYPE_JSON, response.toJSONString()));
+		}
+		return Optional.empty();
+	}
+
+	// Returns a deep copy of the given JSON with every string value run through
+	// urlProcessor.transformURL, so any endpoint URIs are pointed at the local server.
+	private static Object transformDiscoveryJSON(Object json, URLProcessor urlProcessor) {
+		if (json instanceof JSONObject) {
+			JSONObject copy = new JSONObject();
+			((JSONObject) json).forEach((key, value) -> copy.put(key, transformDiscoveryJSON(value, urlProcessor)));
+			return copy;
+		} else if (json instanceof JSONArray) {
+			JSONArray copy = new JSONArray();
+			for (Object element : (JSONArray) json) {
+				copy.add(transformDiscoveryJSON(element, urlProcessor));
+			}
+			return copy;
+		} else if (json instanceof String) {
+			return urlProcessor.transformURL((String) json).orElse((String) json);
+		} else {
+			return json;
+		}
+	}
+}

--- a/src/main/java/moe/yushi/authlibinjector/httpd/LegacySkinAPIFilter.java
+++ b/src/main/java/moe/yushi/authlibinjector/httpd/LegacySkinAPIFilter.java
@@ -58,7 +58,7 @@ public class LegacySkinAPIFilter implements URLFilter {
 	}
 
 	@Override
-	public Optional<Response> handle(String domain, String path, IHTTPSession session) {
+	public Optional<Response> handle(URLProcessor urlProcessor, String domain, String path, IHTTPSession session) {
 		if (!domain.equals("skins.minecraft.net"))
 			return empty();
 		Matcher matcher = PATH_SKINS.matcher(path);

--- a/src/main/java/moe/yushi/authlibinjector/httpd/ProfileKeyFilter.java
+++ b/src/main/java/moe/yushi/authlibinjector/httpd/ProfileKeyFilter.java
@@ -44,7 +44,7 @@ public class ProfileKeyFilter implements URLFilter {
 	}
 
 	@Override
-	public Optional<Response> handle(String domain, String path, IHTTPSession session) throws IOException {
+	public Optional<Response> handle(URLProcessor urlProcessor, String domain, String path, IHTTPSession session) throws IOException {
 		if (domain.equals("api.minecraftservices.com") && path.equals("/player/certificates") && session.getMethod().equals("POST")) {
 			return Optional.of(Response.newFixedLength(Status.OK, CONTENT_TYPE_JSON, makeDummyResponse().toJSONString()));
 		}

--- a/src/main/java/moe/yushi/authlibinjector/httpd/PublickeysFilter.java
+++ b/src/main/java/moe/yushi/authlibinjector/httpd/PublickeysFilter.java
@@ -36,7 +36,7 @@ public class PublickeysFilter implements URLFilter {
 	}
 
 	@Override
-	public Optional<Response> handle(String domain, String path, IHTTPSession session) throws IOException {
+	public Optional<Response> handle(URLProcessor urlProcessor, String domain, String path, IHTTPSession session) throws IOException {
 		if (domain.equals("api.minecraftservices.com") && path.equals("/publickeys") && session.getMethod().equals("GET")) {
 			return Optional.of(Response.newFixedLength(Status.OK, CONTENT_TYPE_JSON, makePublickeysResponse().toJSONString()));
 		}

--- a/src/main/java/moe/yushi/authlibinjector/httpd/QueryProfileFilter.java
+++ b/src/main/java/moe/yushi/authlibinjector/httpd/QueryProfileFilter.java
@@ -51,7 +51,7 @@ public class QueryProfileFilter implements URLFilter {
 	}
 
 	@Override
-	public Optional<Response> handle(String domain, String path, IHTTPSession session) throws IOException {
+	public Optional<Response> handle(URLProcessor urlProcessor, String domain, String path, IHTTPSession session) throws IOException {
 		if (!domain.equals("sessionserver.mojang.com"))
 			return empty();
 		Matcher matcher = PATH_REGEX.matcher(path);

--- a/src/main/java/moe/yushi/authlibinjector/httpd/QueryUUIDsFilter.java
+++ b/src/main/java/moe/yushi/authlibinjector/httpd/QueryUUIDsFilter.java
@@ -53,7 +53,7 @@ public class QueryUUIDsFilter implements URLFilter {
 	}
 
 	@Override
-	public Optional<Response> handle(String domain, String path, IHTTPSession session) throws IOException {
+	public Optional<Response> handle(URLProcessor urlProcessor, String domain, String path, IHTTPSession session) throws IOException {
 		if (
 			(domain.equals("api.mojang.com") && path.equals("/profiles/minecraft") && session.getMethod().equals("POST")) ||
 			(domain.equals("api.minecraftservices.com") && path.equals("/minecraft/profile/lookup/bulk/byname") && session.getMethod().equals("POST"))

--- a/src/main/java/moe/yushi/authlibinjector/httpd/URLFilter.java
+++ b/src/main/java/moe/yushi/authlibinjector/httpd/URLFilter.java
@@ -37,5 +37,5 @@ public interface URLFilter {
 	 */
 	boolean canHandle(String domain);
 
-	Optional<Response> handle(String domain, String path, IHTTPSession session) throws IOException;
+	Optional<Response> handle(URLProcessor urlProcessor, String domain, String path, IHTTPSession session) throws IOException;
 }

--- a/src/main/java/moe/yushi/authlibinjector/httpd/URLProcessor.java
+++ b/src/main/java/moe/yushi/authlibinjector/httpd/URLProcessor.java
@@ -123,6 +123,7 @@ public class URLProcessor {
 	}
 
 	private NanoHTTPD createHttpd() {
+		final URLProcessor urlProcessor = this;
 		return new NanoHTTPD("127.0.0.1", Config.httpdPort) {
 			@Override
 			public Response serve(IHTTPSession session) {
@@ -139,7 +140,7 @@ public class URLProcessor {
 						if (filter.canHandle(domain)) {
 							Optional<Response> result;
 							try {
-								result = filter.handle(domain, path, session);
+								result = filter.handle(urlProcessor, domain, path, session);
 							} catch (Throwable e) {
 								log(WARNING, "An error occurred while processing request [" + session.getUri() + "]", e);
 								return Response.newFixedLength(Status.INTERNAL_ERROR, CONTENT_TYPE_TEXT, "Internal Server Error");

--- a/src/main/java/moe/yushi/authlibinjector/transform/support/ConcatenateURLTransformUnit.java
+++ b/src/main/java/moe/yushi/authlibinjector/transform/support/ConcatenateURLTransformUnit.java
@@ -48,7 +48,7 @@ public class ConcatenateURLTransformUnit implements TransformUnit {
 
 	@Override
 	public Optional<ClassVisitor> transform(ClassLoader classLoader, String className, ClassVisitor writer, TransformContext ctx) {
-		if ("com.mojang.authlib.HttpAuthenticationService".equals(className)) {
+		if ("com.mojang.authlib.HttpAuthenticationService".equals(className) || "com.mojang.authlib.HttpDiscoveryService".equals(className)) {
 			return Optional.of(new ClassVisitor(ASM9, writer) {
 				@Override
 				public MethodVisitor visitMethod(int access, String name, String descriptor, String signature, String[] exceptions) {

--- a/src/main/java/moe/yushi/authlibinjector/transform/support/SkinWhitelistTransformUnit.java
+++ b/src/main/java/moe/yushi/authlibinjector/transform/support/SkinWhitelistTransformUnit.java
@@ -104,7 +104,34 @@ public class SkinWhitelistTransformUnit implements TransformUnit {
 						ctx.markModified();
 						MethodVisitor mv = super.visitMethod(access, name, desc, signature, exceptions);
 						mv.visitCode();
+						// These classes declare isAllowedTextureDomain as a static method,
+						// so the String argument is in local slot 0.
 						mv.visitVarInsn(ALOAD, 0);
+						ctx.invokeCallback(mv, SkinWhitelistTransformUnit.class, "isWhitelistedDomain");
+						mv.visitInsn(IRETURN);
+						mv.visitMaxs(-1, -1);
+						mv.visitEnd();
+						return null;
+					} else {
+						return super.visitMethod(access, name, desc, signature, exceptions);
+					}
+				}
+
+			});
+		} else if ("com.mojang.authlib.services.MinecraftServicesDiscoveryService".equals(className)) {
+			// In com.mojang.authlib 10+, isAllowedTextureDomain became an
+			// instance method on this class, so the String argument is in
+			// local slot 1 (slot 0 is `this`).
+			return Optional.of(new ClassVisitor(ASM9, writer) {
+
+				@Override
+				public MethodVisitor visitMethod(int access, String name, String desc, String signature, String[] exceptions) {
+					if (("isWhitelistedDomain".equals(name) || "isAllowedTextureDomain".equals(name)) &&
+							"(Ljava/lang/String;)Z".equals(desc)) {
+						ctx.markModified();
+						MethodVisitor mv = super.visitMethod(access, name, desc, signature, exceptions);
+						mv.visitCode();
+						mv.visitVarInsn(ALOAD, 1);
 						ctx.invokeCallback(mv, SkinWhitelistTransformUnit.class, "isWhitelistedDomain");
 						mv.visitInsn(IRETURN);
 						mv.visitMaxs(-1, -1);

--- a/src/main/java/moe/yushi/authlibinjector/transform/support/SkinWhitelistTransformUnit.java
+++ b/src/main/java/moe/yushi/authlibinjector/transform/support/SkinWhitelistTransformUnit.java
@@ -19,6 +19,8 @@ package moe.yushi.authlibinjector.transform.support;
 import static org.objectweb.asm.Opcodes.ALOAD;
 import static org.objectweb.asm.Opcodes.ASM9;
 import static org.objectweb.asm.Opcodes.IRETURN;
+import static moe.yushi.authlibinjector.util.Logging.Level.DEBUG;
+import static moe.yushi.authlibinjector.util.Logging.log;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.util.List;
@@ -63,7 +65,7 @@ public class SkinWhitelistTransformUnit implements TransformUnit {
 
 	@CallbackMethod
 	public static boolean isWhitelistedDomain(String url) {
-		System.out.println(url);
+		log(DEBUG, "Checking texture URL whitelist: " + url);
 		String domain;
 		try {
 			domain = new URI(url).getHost();

--- a/src/main/java/moe/yushi/authlibinjector/transform/support/YggdrasilKeyTransformUnit.java
+++ b/src/main/java/moe/yushi/authlibinjector/transform/support/YggdrasilKeyTransformUnit.java
@@ -189,7 +189,7 @@ public class YggdrasilKeyTransformUnit implements TransformUnit {
 				}
 			});
 
-		} else if ("com.mojang.authlib.yggdrasil.YggdrasilServicesKeyInfo".equals(className)) {
+		} else if ("com.mojang.authlib.yggdrasil.YggdrasilServicesKeyInfo".equals(className) || "com.mojang.authlib.services.MinecraftServicesKeyInfo".equals(className)) {
 			return Optional.of(new ClassVisitor(ASM9, writer) {
 				@Override
 				public MethodVisitor visitMethod(int access, String name, String desc, String signature, String[] exceptions) {

--- a/src/main/resources/discovery_minecraftservices_com_minecraft_client.json
+++ b/src/main/resources/discovery_minecraftservices_com_minecraft_client.json
@@ -1,0 +1,77 @@
+{
+  "environment" : "prod",
+  "product" : "minecraft",
+  "discovery" : {
+    "authentication" : {
+      "endpoints" : {
+        "getPublicKeys" : {
+          "uri" : "https://api.minecraftservices.com/publickeys"
+        },
+        "loginXbox" : {
+          "uri" : "https://api.minecraftservices.com/authentication/login_with_xbox"
+        }
+      }
+    },
+    "session" : {
+      "endpoints" : {
+        "getProfileById" : {
+          "uri" : "https://sessionserver.mojang.com/session/minecraft/profile/{profileId}"
+        },
+        "verify" : {
+          "uri" : "https://sessionserver.mojang.com/session/minecraft/hasJoined"
+        },
+        "join" : {
+          "uri" : "https://sessionserver.mojang.com/session/minecraft/join"
+        }
+      }
+    },
+    "player" : {
+      "endpoints" : {
+        "updatePresence" : {
+          "uri" : "https://api.minecraftservices.com/presence"
+        },
+        "sendReport" : {
+          "uri" : "https://api.minecraftservices.com/player/report"
+        },
+        "getAttributes" : {
+          "uri" : "https://api.minecraftservices.com/player/attributes"
+        },
+        "getFriends" : {
+          "uri" : "https://api.minecraftservices.com/friends"
+        },
+        "getCertificates" : {
+          "uri" : "https://api.minecraftservices.com/player/certificates"
+        },
+        "updateAttributes" : {
+          "uri" : "https://api.minecraftservices.com/player/attributes"
+        },
+        "updateFriends" : {
+          "uri" : "https://api.minecraftservices.com/friends"
+        },
+        "getBlocklist" : {
+          "uri" : "https://api.minecraftservices.com/privacy/blocklist"
+        }
+      }
+    },
+    "profiles" : {
+      "endpoints" : {
+        "getManyByName" : {
+          "uri" : "https://api.mojang.com/profiles/minecraft"
+        },
+        "getByName" : {
+          "uri" : "https://api.mojang.com/users/profiles/minecraft/{name}"
+        },
+        "getTexture" : {
+          "validUris" : [ "https://textures.minecraft.net/texture/{textureId}", "http://textures.minecraft.net/texture/{textureId}" ]
+        }
+      }
+    },
+    "telemetry" : {
+      "endpoints" : {
+        "sendEvents" : {
+          "uri" : "https://api.minecraftservices.com/events"
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
Details in commit messages.

This approach of hardcoding Mojang's response from https://discovery.minecraftservices.com/minecraft/client is fragile if a new version of Minecraft depends on a new route; a new release of authlib-injector would be needed. A more robust solution might be for authlib-injector to make the request to https://discovery.minecraftservices.com/minecraft/client at runtime and transform the response, but that would leak to Mojang. Or we could do something like https://github.com/unmojang/FjordLauncher/blob/1cd82462e435329d2c34a1f8c971d943c14926b0/libraries/launcher/legacy/org/prismlauncher/legacy/fix/online/OnlineFixes.java#L55 and patch the HTTP client rather than statically patch URLs in bytecode.

In the future, authlib-injector could specify the discovery endpoint behind a `feature` flag, and authservers could customize the URLs for each endpoint. That would be robust for new routes; authservers could implement them as the authlib-injector spec is updated, no new authlib-injector JARs needed.

Resolves https://github.com/yushijinhun/authlib-injector/issues/298.

Resolves https://github.com/yushijinhun/authlib-injector/issues/300.